### PR TITLE
Feature/UA-339

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -106,11 +106,13 @@ type InflatedSeries struct {
 type Observation struct {
 	Date  time.Time
 	Value sql.NullFloat64
+	PseudoHistory bool
 }
 
 type DataPortalObservation struct {
-	Date  time.Time `json:"date"`
-	Value float64   `json:"value"`
+	Date  time.Time
+	Value float64
+	PseudoHistory bool
 }
 
 type SeriesObservations struct {
@@ -130,9 +132,11 @@ func (o *DataPortalObservation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Date  string `json:"date"`
 		Value string `json:"value"`
+		PseudoHistory bool `json:"pseudoHistory,omitempty"`
 	}{
 		Date:  formatDate(o.Date),
 		Value: fmt.Sprintf("%.4f", o.Value),
+		PseudoHistory: o.PseudoHistory,
 	})
 }
 


### PR DESCRIPTION
Added pseudo_history flag to observation objects. The property `pseudoHistory: true` is only returned when an observation is pseudo history (i.e., is a constructed series).