### PR TITLE
fix sql group errors

### DIFF
--- a/data/search.go
+++ b/data/search.go
@@ -35,7 +35,7 @@ func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, u
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
-	GROUP BY series.id
+	GROUP BY series.id, geographies.fips, geographies.display_name_short
 	LIMIT 50;`, universeText, searchText, searchText)
 	if err != nil {
 		return
@@ -85,7 +85,7 @@ func (r *SeriesRepository) GetSeriesBySearchText(searchText string) (seriesList 
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
-	GROUP BY series.id
+	GROUP BY series.id, geographies.fips, geographies.display_name_short
 	LIMIT 50;`, searchText, searchText)
 	if err != nil {
 		return
@@ -405,7 +405,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreq(
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
 	AND LOWER(series.name) LIKE CONCAT('%@', LOWER(?), '.', LOWER(?))
-	GROUP BY series.id
+	GROUP BY series.id, geographies.fips, geographies.display_name_short
 	LIMIT 50;`,
 		geo,
 		geo,
@@ -474,7 +474,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
 	AND LOWER(series.name) LIKE CONCAT('%@', LOWER(?), '.', LOWER(?))
-	GROUP BY series.id
+	GROUP BY series.id, geographies.fips, geographies.display_name_short
 	LIMIT 50;`,
 		geo,
 		geo,

--- a/data/search.go
+++ b/data/search.go
@@ -19,7 +19,7 @@ func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, u
 	MAX(measurements.table_prefix), MAX(measurements.table_postfix),
 	MAX(measurements.id), MAX(measurements.data_portal_name),
 	NULL, series.base_year, series.decimals,
-	fips, SUBSTRING_INDEX(SUBSTR(series.name, LOCATE('@', series.name) + 1), '.', 1) as shandle, display_name_short
+	MAX(fips), SUBSTRING_INDEX(SUBSTR(series.name, LOCATE('@', series.name) + 1), '.', 1) as shandle, MAX(display_name_short)
 	FROM series
 	LEFT JOIN geographies ON series.name LIKE CONCAT('%@', geographies.handle, '.%')
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
@@ -35,7 +35,7 @@ func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, u
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
-	GROUP BY series.id, geographies.fips, geographies.display_name_short
+	GROUP BY series.id
 	LIMIT 50;`, universeText, searchText, searchText)
 	if err != nil {
 		return
@@ -70,7 +70,7 @@ func (r *SeriesRepository) GetSeriesBySearchText(searchText string) (seriesList 
 	MAX(measurements.table_prefix), MAX(measurements.table_postfix),
 	MAX(measurements.id), MAX(measurements.data_portal_name),
 	NULL, series.base_year, series.decimals,
-	fips, SUBSTRING_INDEX(SUBSTR(series.name, LOCATE('@', series.name) + 1), '.', 1) as shandle, display_name_short
+	MAX(fips), SUBSTRING_INDEX(SUBSTR(series.name, LOCATE('@', series.name) + 1), '.', 1) as shandle, MAX(display_name_short)
 	FROM series
 	LEFT JOIN geographies ON series.name LIKE CONCAT('%@', geographies.handle, '.%')
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
@@ -85,7 +85,7 @@ func (r *SeriesRepository) GetSeriesBySearchText(searchText string) (seriesList 
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
-	GROUP BY series.id, geographies.fips, geographies.display_name_short
+	GROUP BY series.id
 	LIMIT 50;`, searchText, searchText)
 	if err != nil {
 		return
@@ -327,7 +327,7 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreq(searchText string, geo s
 	MAX(measurements.table_prefix), MAX(measurements.table_postfix),
 	MAX(measurements.id), MAX(measurements.data_portal_name),
 	NULL, series.base_year, series.decimals,
-	fips, ?, display_name_short
+	MAX(fips), ?, MAX(display_name_short)
 	FROM series
 	LEFT JOIN geographies ON geographies.handle LIKE ?
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
@@ -389,7 +389,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreq(
 	MAX(measurements.table_prefix), MAX(measurements.table_postfix),
 	MAX(measurements.id), MAX(measurements.data_portal_name),
 	NULL, series.base_year, series.decimals,
-	fips, ?, display_name_short
+	MAX(fips), ?, MAX(display_name_short)
 	FROM series
 	LEFT JOIN geographies ON geographies.handle LIKE ?
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
@@ -405,7 +405,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreq(
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
 	AND LOWER(series.name) LIKE CONCAT('%@', LOWER(?), '.', LOWER(?))
-	GROUP BY series.id, geographies.fips, geographies.display_name_short
+	GROUP BY series.id
 	LIMIT 50;`,
 		geo,
 		geo,
@@ -457,7 +457,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	MAX(measurements.table_prefix), MAX(measurements.table_postfix),
 	MAX(measurements.id), MAX(measurements.data_portal_name),
 	NULL, series.base_year, series.decimals,
-	fips, ?, display_name_short
+	MAX(fips), ?, MAX(display_name_short)
 	FROM series
 	LEFT JOIN geographies ON geographies.handle LIKE ?
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
@@ -474,7 +474,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
 	AND LOWER(series.name) LIKE CONCAT('%@', LOWER(?), '.', LOWER(?))
-	GROUP BY series.id, geographies.fips, geographies.display_name_short
+	GROUP BY series.id
 	LIMIT 50;`,
 		geo,
 		geo,

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -174,10 +174,11 @@ var measurementSeriesPrefix = `SELECT
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
 	WHERE measurements.id = ? AND NOT series.restricted
-	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
+	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
+	GROUP by series.id, geographies.fips, geographies.display_name_short`
 var geoFilter = ` AND series.name LIKE CONCAT('%@', ? ,'.%') `
 var freqFilter = ` AND series.name LIKE CONCAT('%@%.', ?) `
-var sortStmt = ` GROUP BY series.id ORDER BY data_list_measurements.list_order;`
+var sortStmt = ` GROUP by series.id, data_list_measurements.indent, geographies.fips, geographies.display_name_short, data_list_measurements.list_order ORDER BY data_list_measurements.list_order;`
 var siblingsPrefix = `SELECT
         series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(series.unitsLabel, ''), NULLIF(MAX(measurements.units_label), '')),
@@ -201,7 +202,8 @@ var siblingsPrefix = `SELECT
 	LEFT JOIN geographies ON series.name LIKE CONCAT('%@', geographies.handle, '.%')
 	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
 	WHERE NOT series.restricted
-	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
+	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
+	GROUP by series.id, geographies.fips, geographies.display_name_short`
 
 func (r *SeriesRepository) GetSeriesByGroupAndFreq(
 	groupId int64,


### PR DESCRIPTION
I got several errors when deploying the recent update. I'm not sure this is the best way to deal with them, but it fixed the problem.
Endpoints that were throwing errors:
/search/series?q=income&u=uhero&geo=HAW&freq=A&expand=true
/search/series?q=income&u=uhero
/category/series?id=18
/measurement/series?id=4102