### PR TITLE
REST-API Query Refactor (UA-695)

### DIFF
--- a/controllers/searchController.go
+++ b/controllers/searchController.go
@@ -176,6 +176,53 @@ func GetSearchResultByGeoAndFreq(searchRepository *data.SeriesRepository, c *dat
 	}
 }
 
+func GetSearchResultByGeoAndFreqAndUniverse(searchRepository *data.SeriesRepository, c *data.CacheRepository) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		searchText, ok := mux.Vars(r)["search_text"]
+		if !ok {
+			common.DisplayAppError(
+				w,
+				errors.New("Couldn't get searchText from request"),
+				"Bad request.",
+				400,
+			)
+			return
+		}
+		universeText, ok := mux.Vars(r)["universe_text"]
+		if !ok {
+			common.DisplayAppError(
+				w,
+				errors.New("Couldn't get universeText from request"),
+				"Bad request.",
+				400,
+			)
+			return
+		}
+		geo, ok := mux.Vars(r)["geo"]
+		if !ok {
+			common.DisplayAppError(
+				w,
+				errors.New("Couldn't get geography from request"),
+				"Bad request.",
+				400,
+			)
+			return
+		}
+		freq, ok := mux.Vars(r)["freq"]
+		if !ok {
+			common.DisplayAppError(
+				w,
+				errors.New("Couldn't get frequency from request"),
+				"Bad request.",
+				400,
+			)
+			return
+		}
+		seriesList, err := searchRepository.GetSearchResultsByGeoAndFreqAndUniverse(searchText, geo, freq, universeText)
+		returnSeriesList(seriesList, err, w, r, c)
+	}
+}
+
 func GetInflatedSearchResultByGeoAndFreq(searchRepository *data.SeriesRepository, c *data.CacheRepository) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		searchText, ok := mux.Vars(r)["search_text"]

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -122,7 +122,7 @@ func (r *CategoryRepository) GetCategoryById(id int64) (models.Category, error) 
 		LEFT JOIN data_list_measurements ON data_list_measurements.data_list_id = categories.data_list_id
 		LEFT JOIN measurement_series ON measurement_series.measurement_id = data_list_measurements.measurement_id
 		LEFT JOIN series ON series.id = measurement_series.series_id
-		JOIN geographies AS geo ON geo.id = series.geography_id
+		JOIN geographies geo ON geo.id = series.geography_id
 		WHERE categories.id = ?
 		AND NOT categories.hidden
 		AND NOT series.restricted;`, id)

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -16,8 +16,7 @@ type CategoryRepository struct {
 func (r *CategoryRepository) GetAllCategories() (categories []models.Category, err error) {
 	rows, err := r.DB.Query(`SELECT id, name, ancestry, default_handle, default_freq
 							 FROM categories
-							 WHERE universe = 'UHERO'
-							 AND NOT hidden
+							 WHERE NOT hidden
 							 ORDER BY categories.list_order;`)
 	if err != nil {
 		return
@@ -66,8 +65,7 @@ func getParentId(ancestry sql.NullString) (parentId int64) {
 
 func (r *CategoryRepository) GetCategoryRoots() (categories []models.Category, err error) {
 	rows, err := r.DB.Query(`SELECT id, name FROM categories
-				WHERE universe = 'UHERO'
-				AND ancestry IS NULL
+				WHERE ancestry IS NULL
 				AND NOT hidden
 				ORDER BY list_order;`)
 	if err != nil {

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -65,7 +65,11 @@ func getParentId(ancestry sql.NullString) (parentId int64) {
 }
 
 func (r *CategoryRepository) GetCategoryRoots() (categories []models.Category, err error) {
-	rows, err := r.DB.Query("SELECT id, name FROM categories WHERE ancestry IS NULL AND NOT hidden ORDER BY `list_order`;")
+	rows, err := r.DB.Query(`SELECT id, name FROM categories
+				WHERE universe = 'UHERO'
+				AND ancestry IS NULL
+				AND NOT hidden
+				ORDER BY list_order;`)
 	if err != nil {
 		return
 	}

--- a/data/common.go
+++ b/data/common.go
@@ -255,16 +255,13 @@ func getFreqGeoCombinations(r *SeriesRepository, seriesId int64) (
 	[]models.FrequencyGeographies,
 	error,
 ) {
-	rows, err := r.DB.Query(`SELECT geographies.fips, geographies.display_name_short, geofreq.geo, geofreq.freq
-	FROM (SELECT MAX(SUBSTRING_INDEX(SUBSTR(name, LOCATE('@', name) + 1), '.', 1)) as geo,
-		   MAX(RIGHT(name, 1)) as freq
-	FROM (SELECT series.name
+	rows, err := r.DB.Query(
+		`SELECT DISTINCT geo.fips, geo.display_name_short, geo.handle AS geo, RIGHT(series.name, 1) AS freq
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
-		WHERE measurement_series.series_id = ?) AS s
-	GROUP BY SUBSTR(name, LOCATE('@', name) + 1) ORDER BY COUNT(*) DESC) as geofreq
-	LEFT JOIN geographies ON geographies.handle = geofreq.geo WHERE geofreq.geo IS NOT NULL;`, seriesId)
+		JOIN geographies AS geo on geo.id = series.geography_id
+		WHERE measurement_series.series_id = ?;`, seriesId)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/data/common.go
+++ b/data/common.go
@@ -18,6 +18,15 @@ var freqLabel map[string]string = map[string]string{
 	"D": "Daily",
 }
 
+var freqDbNames map[string]string = map[string]string{
+	"A": "year",
+	"S": "semi",
+	"Q": "quarter",
+	"M": "month",
+	"W": "week",
+	"D": "day",
+}
+
 var indentationLevel map[string]int = map[string]int{
 	"indent0": 0,
 	"indent1": 1,

--- a/data/common.go
+++ b/data/common.go
@@ -260,7 +260,7 @@ func getFreqGeoCombinations(r *SeriesRepository, seriesId int64) (
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
-		JOIN geographies AS geo on geo.id = series.geography_id
+		JOIN geographies geo on geo.id = series.geography_id
 		WHERE measurement_series.series_id = ?;`, seriesId)
 	if err != nil {
 		return nil, nil, err

--- a/data/common.go
+++ b/data/common.go
@@ -260,7 +260,7 @@ func getFreqGeoCombinations(r *SeriesRepository, seriesId int64) (
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
-		JOIN geographies geo on geo.id = series.geography_id
+		LEFT JOIN geographies geo on geo.id = series.geography_id
 		WHERE measurement_series.series_id = ?;`, seriesId)
 	if err != nil {
 		return nil, nil, err

--- a/data/geoRepository.go
+++ b/data/geoRepository.go
@@ -11,7 +11,7 @@ type GeographyRepository struct {
 }
 
 func (r *GeographyRepository) GetAllGeographies() (geographies []models.DataPortalGeography, err error) {
-	rows, err := r.DB.Query(`SELECT fips, display_name, handle FROM geographies where universe = 'UHERO';`)
+	rows, err := r.DB.Query(`SELECT fips, display_name, handle FROM geographies;`)
 	if err != nil {
 		return
 	}
@@ -82,10 +82,10 @@ func (r *GeographyRepository) GetSeriesSiblingsGeoById(seriesId int64) (geograph
 	rows, err := r.DB.Query(
 		`SELECT DISTINCT geographies.fips, geographies.display_name_short, geographies.handle
 		FROM series
-		JOIN (SELECT name FROM series where id = ?) AS original_series
+		JOIN (SELECT name, universe FROM series where id = ?) AS original_series
 		LEFT JOIN geographies ON geographies.id = series.geography_id
 		LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
-		WHERE series.universe = 'UHERO'
+		WHERE series.universe = original_series.universe
 		AND substring_index(series.name, '@', 1) = substring_index(original_series.name, '@', 1)
 		AND NOT series.restricted
 		AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined);`, seriesId)

--- a/data/geoRepository.go
+++ b/data/geoRepository.go
@@ -44,7 +44,7 @@ func (r *GeographyRepository) GetGeographiesByCategory(categoryId int64) (geogra
 		LEFT JOIN data_list_measurements ON data_list_measurements.data_list_id = categories.data_list_id
 		LEFT JOIN measurement_series ON measurement_series.measurement_id = data_list_measurements.measurement_id
 		LEFT JOIN series ON series.id = measurement_series.series_id
-		     JOIN geographies ON geographies.id = series.geography_id
+		LEFT JOIN geographies ON geographies.id = series.geography_id
 		LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 		WHERE (categories.id = ? OR categories.ancestry REGEXP CONCAT('[[:<:]]', ?, '[[:>:]]'))
 		AND NOT categories.hidden
@@ -83,7 +83,7 @@ func (r *GeographyRepository) GetSeriesSiblingsGeoById(seriesId int64) (geograph
 		`SELECT DISTINCT geographies.fips, geographies.display_name_short, geographies.handle
 		FROM series
 		JOIN (SELECT name FROM series where id = ?) AS original_series
-		JOIN geographies ON geographies.id = series.geography_id
+		LEFT JOIN geographies ON geographies.id = series.geography_id
 		LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 		WHERE series.universe = 'UHERO'
 		AND substring_index(series.name, '@', 1) = substring_index(original_series.name, '@', 1)

--- a/data/geoRepository.go
+++ b/data/geoRepository.go
@@ -11,7 +11,7 @@ type GeographyRepository struct {
 }
 
 func (r *GeographyRepository) GetAllGeographies() (geographies []models.DataPortalGeography, err error) {
-	rows, err := r.DB.Query(`SELECT fips, display_name, handle FROM geographies;`)
+	rows, err := r.DB.Query(`SELECT fips, display_name, handle FROM geographies where universe = 'UHERO';`)
 	if err != nil {
 		return
 	}

--- a/data/geoRepository.go
+++ b/data/geoRepository.go
@@ -39,21 +39,17 @@ func (r *GeographyRepository) GetAllGeographies() (geographies []models.DataPort
 
 func (r *GeographyRepository) GetGeographiesByCategory(categoryId int64) (geographies []models.DataPortalGeography, err error) {
 	rows, err := r.DB.Query(
-		`SELECT geographies.fips, geographies.display_name_short, geographies.handle
-		 FROM (
-			SELECT DISTINCT(SUBSTRING_INDEX(SUBSTR(series.name, LOCATE('@', series.name) + 1), '.', 1)) AS handle
-			FROM categories
-			LEFT JOIN data_list_measurements ON data_list_measurements.data_list_id = categories.data_list_id
-			LEFT JOIN measurement_series ON measurement_series.measurement_id = data_list_measurements.measurement_id
-			LEFT JOIN series ON series.id = measurement_series.series_id
-			LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-			WHERE (categories.id = ? OR categories.ancestry REGEXP CONCAT('[[:<:]]', ?, '[[:>:]]'))
-			AND NOT categories.hidden
-			AND NOT series.restricted
-			AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
-		 ) AS category_handles
-		 LEFT JOIN geographies ON geographies.handle LIKE category_handles.handle
-		 WHERE geographies.handle IS NOT NULL;`,
+		`SELECT DISTINCT geographies.fips, geographies.display_name_short, geographies.handle
+		FROM categories
+		LEFT JOIN data_list_measurements ON data_list_measurements.data_list_id = categories.data_list_id
+		LEFT JOIN measurement_series ON measurement_series.measurement_id = data_list_measurements.measurement_id
+		LEFT JOIN series ON series.id = measurement_series.series_id
+		     JOIN geographies ON geographies.id = series.geography_id
+		LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
+		WHERE (categories.id = ? OR categories.ancestry REGEXP CONCAT('[[:<:]]', ?, '[[:>:]]'))
+		AND NOT categories.hidden
+		AND NOT series.restricted
+		AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined);`,
 		categoryId,
 		categoryId,
 	)
@@ -83,20 +79,16 @@ func (r *GeographyRepository) GetGeographiesByCategory(categoryId int64) (geogra
 }
 
 func (r *GeographyRepository) GetSeriesSiblingsGeoById(seriesId int64) (geographies []models.DataPortalGeography, err error) {
-	rows, err := r.DB.Query(`SELECT
-		  geographies.fips, geographies.display_name_short,
-		  catgeo.chandle AS handle
-		FROM
-		  (SELECT DISTINCT(SUBSTRING_INDEX(SUBSTR(catnames.name, LOCATE('@', catnames.name) + 1), '.', 1)) AS chandle
-		    FROM
-		      (SELECT series.name AS name
-				FROM series JOIN (SELECT name FROM series where id = ?) as original_series
-				LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-				WHERE series.name LIKE CONCAT(left(original_series.name, locate("@", original_series.name)), '%')
-				AND NOT series.restricted
-				AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined))
-				AS catnames) AS catgeo
-			LEFT JOIN geographies ON catgeo.chandle LIKE geographies.handle;`, seriesId)
+	rows, err := r.DB.Query(
+		`SELECT DISTINCT geographies.fips, geographies.display_name_short, geographies.handle
+		FROM series
+		JOIN (SELECT name FROM series where id = ?) AS original_series
+		JOIN geographies ON geographies.id = series.geography_id
+		LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
+		WHERE series.universe = 'UHERO'
+		AND substring_index(series.name, '@', 1) = substring_index(original_series.name, '@', 1)
+		AND NOT series.restricted
+		AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined);`, seriesId)
 	if err != nil {
 		return
 	}

--- a/data/search.go
+++ b/data/search.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/UHERO/rest-api/models"
+	"strings"
 )
 
 func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, universeText string) (seriesList []models.DataPortalSeries, err error) {
@@ -212,7 +213,7 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreqAndUniverse(
 	LIMIT 50;`,
 		universeText,
 		geo,
-		freqDbNames[freq],
+		freqDbNames[strings.ToUpper(freq)],
 		searchText,
 		searchText,
 	)
@@ -283,7 +284,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	LIMIT 50;`,
 		universeText,
 		geo,
-		freqDbNames[freq],
+		freqDbNames[strings.ToUpper(freq)],
 		searchText,
 		searchText,
 	)

--- a/data/search.go
+++ b/data/search.go
@@ -22,7 +22,7 @@ func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, u
 	NULL, series.base_year, series.decimals,
 	MAX(geo.fips), MAX(geo.handle) AS shandle, MAX(geo.display_name_short)
 	FROM series
-	JOIN geographies geo ON geo.id = series.geography_id
+	LEFT JOIN geographies geo ON geo.id = series.geography_id
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
 	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
 	LEFT JOIN units ON units.id = series.unit_id
@@ -94,7 +94,7 @@ func (r *SeriesRepository) GetSearchSummaryByUniverse(searchText string, univers
 	rows, err := r.DB.Query(`
 	SELECT DISTINCT geo.fips, geo.display_name_short, geo.handle AS geo, RIGHT(series.name, 1) as freq
 	FROM series
-	  JOIN geographies geo on geo.id = series.geography_id
+	  LEFT JOIN geographies geo on geo.id = series.geography_id
     	  LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE series.universe = UPPER(?)
 	AND NOT series.restricted
@@ -192,7 +192,7 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreqAndUniverse(
 	NULL, series.base_year, series.decimals,
 	MAX(geo.fips), MAX(geo.handle), MAX(geo.display_name_short)
 	FROM series
-	JOIN geographies geo ON geo.id = series.geography_id
+	LEFT JOIN geographies geo ON geo.id = series.geography_id
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
 	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
 	LEFT JOIN units ON units.id = series.unit_id
@@ -263,7 +263,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	NULL, series.base_year, series.decimals,
 	MAX(geo.fips), MAX(geo.handle), MAX(geo.display_name_short)
 	FROM series
-	JOIN geographies geo ON geo.id = series.geography_id
+	LEFT JOIN geographies geo ON geo.id = series.geography_id
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
 	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
 	LEFT JOIN units ON units.id = series.unit_id

--- a/data/search.go
+++ b/data/search.go
@@ -10,8 +10,8 @@ import (
 func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, universeText string) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(`SELECT
 	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
-	COALESCE(NULLIF(series.unitsLabel, ''), NULLIF(MAX(measurements.units_label), '')),
-	COALESCE(NULLIF(series.unitsLabelShort, ''), NULLIF(MAX(measurements.units_label_short), '')),
+	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
+	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
 	COALESCE(NULLIF(sources.description, ''), NULLIF(MAX(measurement_sources.description), '')),
 	COALESCE(NULLIF(series.source_link, ''), NULLIF(MAX(measurements.source_link), ''), NULLIF(sources.link, ''), NULLIF(MAX(measurement_sources.link), '')),
@@ -24,6 +24,8 @@ func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, u
 	LEFT JOIN geographies ON series.name LIKE CONCAT('%@', geographies.handle, '.%')
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
 	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
+	LEFT JOIN units ON units.id = series.unit_id
+	LEFT JOIN units AS measurement_units ON measurement_units.id = measurements.unit_id
 	LEFT JOIN sources ON sources.id = series.source_id
 	LEFT JOIN sources AS measurement_sources ON measurement_sources.id = measurements.source_id
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
@@ -178,8 +180,8 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreqAndUniverse(
 ) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(`SELECT
 	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
-	COALESCE(NULLIF(series.unitsLabel, ''), NULLIF(MAX(measurements.units_label), '')),
-	COALESCE(NULLIF(series.unitsLabelShort, ''), NULLIF(MAX(measurements.units_label_short), '')),
+	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
+	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
 	COALESCE(NULLIF(sources.description, ''), NULLIF(MAX(measurement_sources.description), '')),
 	COALESCE(NULLIF(series.source_link, ''), NULLIF(MAX(measurements.source_link), ''), NULLIF(sources.link, ''), NULLIF(MAX(measurement_sources.link), '')),
@@ -192,6 +194,8 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreqAndUniverse(
 	LEFT JOIN geographies ON geographies.handle LIKE ?
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
 	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
+	LEFT JOIN units ON units.id = series.unit_id
+	LEFT JOIN units AS measurement_units ON measurement_units.id = measurements.unit_id
 	LEFT JOIN sources ON sources.id = series.source_id
 	LEFT JOIN sources AS measurement_sources ON measurement_sources.id = measurements.source_id
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
@@ -247,8 +251,8 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 ) (seriesList []models.InflatedSeries, err error) {
 	rows, err := r.DB.Query(`SELECT DISTINCT
 	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
-	COALESCE(NULLIF(series.unitsLabel, ''), NULLIF(MAX(measurements.units_label), '')),
-	COALESCE(NULLIF(series.unitsLabelShort, ''), NULLIF(MAX(measurements.units_label_short), '')),
+	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
+	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
 	COALESCE(NULLIF(sources.description, ''), NULLIF(MAX(measurement_sources.description), '')),
 	COALESCE(NULLIF(series.source_link, ''), NULLIF(MAX(measurements.source_link), ''), NULLIF(sources.link, ''), NULLIF(MAX(measurement_sources.link), '')),
@@ -261,6 +265,8 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	LEFT JOIN geographies ON geographies.handle LIKE ?
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
 	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
+	LEFT JOIN units ON units.id = series.unit_id
+	LEFT JOIN units AS measurement_units ON measurement_units.id = measurements.unit_id
 	LEFT JOIN sources ON sources.id = series.source_id
 	LEFT JOIN sources AS measurement_sources ON measurement_sources.id = measurements.source_id
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id

--- a/data/search.go
+++ b/data/search.go
@@ -80,8 +80,8 @@ func (r *SeriesRepository) GetSeriesBySearchText(searchText string) (seriesList 
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-	WHERE NOT series.restricted
-	AND series.name NOT LIKE 'DBEDT%'
+	WHERE series.universe = 'UHERO'
+	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
@@ -116,7 +116,7 @@ func (r *SeriesRepository) GetSearchSummary(searchText string) (searchSummary mo
 	FROM series
  	LEFT JOIN public_data_points ON public_data_points.series_id = series.id
  	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-	WHERE series.name NOT LIKE 'DBEDT%'
+	WHERE series.universe = 'UHERO'
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
 	AND NOT series.restricted
@@ -138,8 +138,8 @@ func (r *SeriesRepository) GetSearchSummary(searchText string) (searchSummary mo
 FROM (SELECT MAX(SUBSTRING_INDEX(SUBSTR(s.name, LOCATE('@', s.name) + 1), '.', 1)) as geo, MAX(RIGHT(s.name, 1)) as freq
       FROM (SELECT series.name FROM series
 			  LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-			WHERE NOT restricted
-				AND series.name NOT LIKE 'DBEDT%'
+			WHERE series.universe = 'UHERO'
+				AND NOT restricted
 					AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 					AND (MATCH(series.name, series.description, dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
                                  OR LOWER(CONCAT(series.name, series.description, dataPortalName)) LIKE CONCAT('%', LOWER(?), '%')) AS s
@@ -337,8 +337,8 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreq(searchText string, geo s
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-	WHERE NOT series.restricted
-	AND series.name NOT LIKE 'DBEDT%'
+	WHERE series.universe = 'UHERO'
+	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
@@ -399,8 +399,8 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreq(
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-	WHERE NOT series.restricted
-	AND series.name NOT LIKE 'DBEDT%'
+	WHERE series.universe = 'UHERO'
+	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))

--- a/data/search.go
+++ b/data/search.go
@@ -97,7 +97,7 @@ func (r *SeriesRepository) GetSearchSummaryByUniverse(searchText string, univers
 	  JOIN geographies geo on geo.id = series.geography_id
     	  LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE series.universe = UPPER(?)
-	AND NOT restricted
+	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT quarantined)
 	AND ((MATCH(series.name, series.description, dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	   OR LOWER(CONCAT(series.name, series.description, dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))

--- a/data/search.go
+++ b/data/search.go
@@ -92,9 +92,9 @@ func (r *SeriesRepository) GetSearchSummaryByUniverse(searchText string, univers
 	}
 
 	rows, err := r.DB.Query(`
-	SELECT DISTINCT g.fips, g.display_name_short, g.handle AS geo, RIGHT(series.name, 1) as freq
+	SELECT DISTINCT geo.fips, geo.display_name_short, geo.handle AS geo, RIGHT(series.name, 1) as freq
 	FROM series
-	  JOIN geographies g on g.id = series.geography_id
+	  JOIN geographies geo on geo.id = series.geography_id
     	  LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE series.universe = UPPER(?)
 	AND NOT restricted

--- a/data/search.go
+++ b/data/search.go
@@ -7,15 +7,6 @@ import (
 	"github.com/UHERO/rest-api/models"
 )
 
-var freqNames map[string]string = map[string]string{
-	"A": "year",
-	"Q": "quarter",
-	"M": "month",
-	"S": "semi",
-	"W": "week",
-	"D": "day",
-}
-
 func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, universeText string) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(`SELECT
 	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
@@ -221,7 +212,7 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreqAndUniverse(
 	LIMIT 50;`,
 		universeText,
 		geo,
-		freqNames[freq],
+		freqDbNames[freq],
 		searchText,
 		searchText,
 	)
@@ -291,7 +282,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	LIMIT 50;`,
 		universeText,
 		geo,
-		freqNames[freq],
+		freqDbNames[freq],
 		searchText,
 		searchText,
 	)

--- a/data/search.go
+++ b/data/search.go
@@ -28,10 +28,9 @@ func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, u
 	LEFT JOIN sources AS measurement_sources ON measurement_sources.id = measurements.source_id
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
-	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-	LEFT JOIN public_data_points ON public_data_points.series_id = series.id
-	WHERE NOT series.restricted
-	AND public_data_points.universe = UPPER(?)
+	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
+	WHERE series.universe = UPPER(?)
+	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
@@ -59,155 +58,7 @@ func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, u
 }
 
 func (r *SeriesRepository) GetSeriesBySearchText(searchText string) (seriesList []models.DataPortalSeries, err error) {
-	rows, err := r.DB.Query(`SELECT
-	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
-	COALESCE(NULLIF(series.unitsLabel, ''), NULLIF(MAX(measurements.units_label), '')),
-	COALESCE(NULLIF(series.unitsLabelShort, ''), NULLIF(MAX(measurements.units_label_short), '')),
-	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
-	COALESCE(NULLIF(sources.description, ''), NULLIF(MAX(measurement_sources.description), '')),
-	COALESCE(NULLIF(series.source_link, ''), NULLIF(MAX(measurements.source_link), ''), NULLIF(sources.link, ''), NULLIF(MAX(measurement_sources.link), '')),
-	COALESCE(NULLIF(source_details.description, ''), NULLIF(MAX(measurement_source_details.description), '')),
-	MAX(measurements.table_prefix), MAX(measurements.table_postfix),
-	MAX(measurements.id), MAX(measurements.data_portal_name),
-	NULL, series.base_year, series.decimals,
-	MAX(fips), SUBSTRING_INDEX(SUBSTR(series.name, LOCATE('@', series.name) + 1), '.', 1) as shandle, MAX(display_name_short)
-	FROM series
-	LEFT JOIN geographies ON series.name LIKE CONCAT('%@', geographies.handle, '.%')
-	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
-	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
-	LEFT JOIN sources ON sources.id = series.source_id
-	LEFT JOIN sources AS measurement_sources ON measurement_sources.id = measurements.source_id
-	LEFT JOIN source_details ON source_details.id = series.source_detail_id
-	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
-	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-	WHERE series.universe = 'UHERO'
-	AND NOT series.restricted
-	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
-	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
-	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
-	GROUP BY series.id
-	LIMIT 50;`, searchText, searchText)
-	if err != nil {
-		return
-	}
-	for rows.Next() {
-		dataPortalSeries, scanErr := getNextSeriesFromRows(rows)
-		if scanErr != nil {
-			return seriesList, scanErr
-		}
-		geoFreqs, freqGeos, err := getFreqGeoCombinations(r, dataPortalSeries.Id)
-		if err != nil {
-			return seriesList, err
-		}
-		dataPortalSeries.GeographyFrequencies = &geoFreqs
-		dataPortalSeries.FrequencyGeographies = &freqGeos
-		dataPortalSeries.GeoFreqsDeprecated = &geoFreqs
-		dataPortalSeries.FreqGeosDeprecated = &freqGeos
-		seriesList = append(seriesList, dataPortalSeries)
-	}
-	return
-}
-
-func (r *SeriesRepository) GetSearchSummary(searchText string) (searchSummary models.SearchSummary, err error) {
-	searchSummary.SearchText = searchText
-
-	var observationStart, observationEnd models.NullTime
-	err = r.DB.QueryRow(`SELECT MIN(public_data_points.date) AS start_date, MAX(public_data_points.date) AS end_date
-	FROM series
- 	LEFT JOIN public_data_points ON public_data_points.series_id = series.id
- 	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-	WHERE series.universe = 'UHERO'
-	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
-	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
-	AND NOT series.restricted
-	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`, searchText, searchText).Scan(
-		&observationStart,
-		&observationEnd,
-	)
-	if err != nil {
-		return
-	}
-	if observationStart.Valid && observationStart.Time.After(time.Time{}) {
-		searchSummary.ObservationStart = &observationStart.Time
-	}
-	if observationEnd.Valid && observationEnd.Time.After(time.Time{}) {
-		searchSummary.ObservationEnd = &observationEnd.Time
-	}
-
-	rows, err := r.DB.Query(`SELECT geographies.fips, geographies.display_name_short, geofreq.geo, geofreq.freq
-FROM (SELECT MAX(SUBSTRING_INDEX(SUBSTR(s.name, LOCATE('@', s.name) + 1), '.', 1)) as geo, MAX(RIGHT(s.name, 1)) as freq
-      FROM (SELECT series.name FROM series
-			  LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-			WHERE series.universe = 'UHERO'
-				AND NOT restricted
-					AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
-					AND (MATCH(series.name, series.description, dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
-                                 OR LOWER(CONCAT(series.name, series.description, dataPortalName)) LIKE CONCAT('%', LOWER(?), '%')) AS s
-GROUP BY SUBSTR(s.name, LOCATE('@', s.name) + 1) ORDER BY COUNT(*) DESC) as geofreq
-LEFT JOIN geographies ON geographies.handle = geofreq.geo;`, searchText, searchText)
-	if err != nil {
-		return
-	}
-	geoFreqs := map[string][]models.FrequencyResult{}
-	geoByHandle := map[string]models.DataPortalGeography{}
-	freqGeos := map[string][]models.DataPortalGeography{}
-	freqByHandle := map[string]models.FrequencyResult{}
-
-	for rows.Next() {
-		scangeo := models.Geography{}
-		frequency := models.FrequencyResult{}
-		err = rows.Scan(
-			&scangeo.FIPS,
-			&scangeo.Name,
-			&scangeo.Handle,
-			&frequency.Freq,
-		)
-		geography := models.DataPortalGeography{Handle: scangeo.Handle}
-		if scangeo.FIPS.Valid {
-			geography.FIPS = scangeo.FIPS.String
-		}
-		if scangeo.Name.Valid {
-			geography.Name = scangeo.Name.String
-		}
-		frequency.Label = freqLabel[frequency.Freq]
-		// set the default as the first in the sorted list
-		if searchSummary.DefaultGeoFreq == nil {
-			searchSummary.DefaultGeoFreq = &models.GeographyFrequency{
-				Geography: geography,
-				Frequency: frequency,
-			}
-		}
-		// update the freq and geo maps
-		geoByHandle[geography.Handle] = geography
-		freqByHandle[frequency.Freq] = frequency
-		// add to the geoFreqs and freqGeos maps
-		geoFreqs[geography.Handle] = append(geoFreqs[geography.Handle], frequency)
-		freqGeos[frequency.Freq] = append(freqGeos[frequency.Freq], geography)
-	}
-
-	geoFreqsResult := []models.GeographyFrequencies{}
-	for geo, freqs := range geoFreqs {
-		sort.Sort(models.ByFrequency(freqs))
-		geoFreqsResult = append(geoFreqsResult, models.GeographyFrequencies{
-			DataPortalGeography: geoByHandle[geo],
-			Frequencies:         freqs,
-		})
-	}
-
-	freqGeosResult := []models.FrequencyGeographies{}
-	for _, freq := range models.FreqOrder {
-		if val, ok := freqByHandle[freq]; ok {
-			freqGeosResult = append(freqGeosResult, models.FrequencyGeographies{
-				FrequencyResult: val,
-				Geographies:     freqGeos[freq],
-			})
-		}
-	}
-
-	searchSummary.GeographyFrequencies = &geoFreqsResult
-	searchSummary.FrequencyGeographies = &freqGeosResult
-	searchSummary.GeoFreqsDeprecated = &geoFreqsResult
-	searchSummary.FreqGeosDeprecated = &freqGeosResult
+	seriesList, err = r.GetSeriesBySearchTextAndUniverse(searchText, "UHERO")
 	return
 }
 
@@ -218,7 +69,7 @@ func (r *SeriesRepository) GetSearchSummaryByUniverse(searchText string, univers
 	err = r.DB.QueryRow(`SELECT MIN(public_data_points.date) AS start_date, MAX(public_data_points.date) AS end_date
 	FROM series
  	LEFT JOIN public_data_points ON public_data_points.series_id = series.id
- 	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
+ 	LEFT JOIN feature_toggles ON feature_toggles.universe = public_data_points.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE public_data_points.universe = UPPER(?)
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
@@ -240,13 +91,12 @@ func (r *SeriesRepository) GetSearchSummaryByUniverse(searchText string, univers
 	rows, err := r.DB.Query(`SELECT geographies.fips, geographies.display_name_short, geofreq.geo, geofreq.freq
 FROM (SELECT MAX(SUBSTRING_INDEX(SUBSTR(s.name, LOCATE('@', s.name) + 1), '.', 1)) as geo, MAX(RIGHT(s.name, 1)) as freq
       FROM (SELECT series.name FROM series
-			  LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-			  LEFT JOIN public_data_points ON public_data_points.series_id = series.id
-			WHERE NOT restricted
-				AND public_data_points.universe = UPPER(?)
-					AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
-					AND ((MATCH(series.name, series.description, dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
-                                 OR LOWER(CONCAT(series.name, series.description, dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))) AS s
+			  LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
+			WHERE series.universe = UPPER(?)
+			AND NOT restricted
+			AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
+			AND ((MATCH(series.name, series.description, dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
+                           OR LOWER(CONCAT(series.name, series.description, dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))) AS s
 GROUP BY SUBSTR(s.name, LOCATE('@', s.name) + 1) ORDER BY COUNT(*) DESC) as geofreq
 LEFT JOIN geographies ON geographies.handle = geofreq.geo;`, universeText, searchText, searchText)
 	if err != nil {
@@ -315,6 +165,11 @@ LEFT JOIN geographies ON geographies.handle = geofreq.geo;`, universeText, searc
 	return
 }
 
+func (r *SeriesRepository) GetSearchSummary(searchText string) (searchSummary models.SearchSummary, err error) {
+	searchSummary, err = r.GetSearchSummaryByUniverse(searchText, "UHERO")
+	return
+}
+
 func (r *SeriesRepository) GetSearchResultsByGeoAndFreq(searchText string, geo string, freq string) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(`SELECT
 	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
@@ -336,7 +191,7 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreq(searchText string, geo s
 	LEFT JOIN sources AS measurement_sources ON measurement_sources.id = measurements.source_id
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
-	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
+	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE series.universe = 'UHERO'
 	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
@@ -373,73 +228,6 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreq(searchText string, geo s
 	return
 }
 
-func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreq(
-	searchText string,
-	geo string,
-	freq string,
-) (seriesList []models.InflatedSeries, err error) {
-	rows, err := r.DB.Query(`SELECT
-	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
-	COALESCE(NULLIF(series.unitsLabel, ''), NULLIF(MAX(measurements.units_label), '')),
-	COALESCE(NULLIF(series.unitsLabelShort, ''), NULLIF(MAX(measurements.units_label_short), '')),
-	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
-	COALESCE(NULLIF(sources.description, ''), NULLIF(MAX(measurement_sources.description), '')),
-	COALESCE(NULLIF(series.source_link, ''), NULLIF(MAX(measurements.source_link), ''), NULLIF(sources.link, ''), NULLIF(MAX(measurement_sources.link), '')),
-	COALESCE(NULLIF(source_details.description, ''), NULLIF(MAX(measurement_source_details.description), '')),
-	MAX(measurements.table_prefix), MAX(measurements.table_postfix),
-	MAX(measurements.id), MAX(measurements.data_portal_name),
-	NULL, series.base_year, series.decimals,
-	MAX(fips), ?, MAX(display_name_short)
-	FROM series
-	LEFT JOIN geographies ON geographies.handle LIKE ?
-	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
-	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
-	LEFT JOIN sources ON sources.id = series.source_id
-	LEFT JOIN sources AS measurement_sources ON measurement_sources.id = measurements.source_id
-	LEFT JOIN source_details ON source_details.id = series.source_detail_id
-	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
-	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-	WHERE series.universe = 'UHERO'
-	AND NOT series.restricted
-	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
-	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
-	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
-	AND LOWER(series.name) LIKE CONCAT('%@', LOWER(?), '.', LOWER(?))
-	GROUP BY series.id
-	LIMIT 50;`,
-		geo,
-		geo,
-		searchText,
-		searchText,
-		geo,
-		freq,
-	)
-	if err != nil {
-		return
-	}
-	for rows.Next() {
-		dataPortalSeries, scanErr := getNextSeriesFromRows(rows)
-		if scanErr != nil {
-			return seriesList, scanErr
-		}
-		geoFreqs, freqGeos, err := getFreqGeoCombinations(r, dataPortalSeries.Id)
-		if err != nil {
-			return seriesList, err
-		}
-		dataPortalSeries.GeographyFrequencies = &geoFreqs
-		dataPortalSeries.FrequencyGeographies = &freqGeos
-		dataPortalSeries.GeoFreqsDeprecated = &geoFreqs
-		dataPortalSeries.FreqGeosDeprecated = &freqGeos
-		seriesObservations, scanErr := r.GetSeriesObservations(dataPortalSeries.Id)
-		if scanErr != nil {
-			return seriesList, scanErr
-		}
-		inflatedSeries := models.InflatedSeries{dataPortalSeries, seriesObservations}
-		seriesList = append(seriesList, inflatedSeries)
-	}
-	return
-}
-
 func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	searchText string,
 	geo string,
@@ -466,10 +254,9 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	LEFT JOIN sources AS measurement_sources ON measurement_sources.id = measurements.source_id
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
-	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
-	LEFT JOIN public_data_points ON public_data_points.series_id = series.id
-	WHERE NOT series.restricted
-	AND public_data_points.universe = UPPER(?)
+	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
+	WHERE series.universe = UPPER(?)
+	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR LOWER(CONCAT(series.name, series.description, series.dataPortalName)) LIKE CONCAT('%', LOWER(?), '%'))
@@ -507,5 +294,14 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 		inflatedSeries := models.InflatedSeries{dataPortalSeries, seriesObservations}
 		seriesList = append(seriesList, inflatedSeries)
 	}
+	return
+}
+
+func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreq(
+	searchText string,
+	geo string,
+	freq string,
+) (seriesList []models.InflatedSeries, err error) {
+	seriesList, err = r.GetInflatedSearchResultsByGeoAndFreqAndUniverse(searchText, geo, freq, "UHERO")
 	return
 }

--- a/data/search.go
+++ b/data/search.go
@@ -216,6 +216,7 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreqAndUniverse(
 		searchText,
 		searchText,
 	)
+
 	if err != nil {
 		return
 	}

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -179,7 +179,7 @@ var measurementSeriesPrefix = `SELECT
 	LEFT JOIN feature_toggles ON feature_toggles.universe = measurements.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE measurements.id = ? AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
-var geoFilter = ` AND geographies.handle = ? `
+var geoFilter = ` AND geographies.handle = UPPER(?) `
 var freqFilter = ` AND series.frequency = ? `
 var measurementPostfix = ` GROUP BY series.id;`
 var sortStmt = ` GROUP BY series.id ORDER BY MAX(data_list_measurements.list_order);`
@@ -225,7 +225,7 @@ func (r *SeriesRepository) GetSeriesByGroupAndFreq(
 	rows, err := r.DB.Query(
 		strings.Join([]string{prefix, freqFilter, sort}, ""),
 		groupId,
-		freqDbNames[freq],
+		freqDbNames[strings.ToUpper(freq)],
 	)
 	if err != nil {
 		return
@@ -264,7 +264,7 @@ func (r *SeriesRepository) GetSeriesByGroupGeoAndFreq(
 		strings.Join([]string{prefix, geoFilter, freqFilter, sort}, ""),
 		groupId,
 		geoHandle,
-		freqDbNames[freq],
+		freqDbNames[strings.ToUpper(freq)],
 	)
 	if err != nil {
 		return
@@ -303,7 +303,7 @@ func (r *SeriesRepository) GetInflatedSeriesByGroupGeoAndFreq(
 		strings.Join([]string{prefix, geoFilter, freqFilter, sort}, ""),
 		groupId,
 		geoHandle,
-		freqDbNames[freq],
+		freqDbNames[strings.ToUpper(freq)],
 	)
 	if err != nil {
 		return
@@ -502,7 +502,7 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdAndFreq(
 	seriesId int64,
 	freq string,
 ) (seriesList []models.DataPortalSeries, err error) {
-	rows, err := r.DB.Query(strings.Join([]string{siblingsPrefix, freqFilter}, ""), seriesId, freqDbNames[freq])
+	rows, err := r.DB.Query(strings.Join([]string{siblingsPrefix, freqFilter}, ""), seriesId, freqDbNames[strings.ToUpper(freq)])
 	if err != nil {
 		return
 	}
@@ -557,7 +557,7 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdGeoAndFreq(
 ) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(
 		strings.Join([]string{siblingsPrefix, geoFilter, freqFilter}, ""),
-		seriesId, geo, freqDbNames[freq])
+		seriesId, geo, freqDbNames[strings.ToUpper(freq)])
 	if err != nil {
 		return
 	}

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -625,7 +625,7 @@ func (r *SeriesRepository) GetSeriesById(seriesId int64) (dataPortalSeries model
 	series.base_year, series.decimals,
 	geo.fips, geo.handle AS shandle, geo.display_name_short
 	FROM series
-	JOIN geographies geo ON geo.id = series.geography_id
+	LEFT JOIN geographies geo ON geo.id = series.geography_id
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
 	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
 	LEFT JOIN units ON units.id = series.unit_id

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -136,7 +136,7 @@ var seriesPrefix = `SELECT
 	MAX(measurements.table_prefix), MAX(measurements.table_postfix),
 	MAX(measurements.id), MAX(measurements.data_portal_name),
 	MAX(data_list_measurements.indent), series.base_year, series.decimals,
-	MAX(fips), SUBSTRING_INDEX(SUBSTR(series.name, LOCATE('@', series.name) + 1), '.', 1) as shandle, MAX(display_name_short)
+	MAX(geographies.fips), MAX(geographies.handle) AS shandle, MAX(geographies.display_name_short)
 	FROM series
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
 	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
@@ -165,7 +165,7 @@ var measurementSeriesPrefix = `SELECT
 	MAX(measurements.table_prefix), MAX(measurements.table_postfix),
 	MAX(measurements.id), MAX(measurements.data_portal_name),
 	NULL, series.base_year, series.decimals,
-	MAX(fips), SUBSTRING_INDEX(SUBSTR(series.name, LOCATE('@', series.name) + 1), '.', 1) as shandle, MAX(display_name_short)
+	MAX(geographies.fips), MAX(geographies.handle) AS shandle, MAX(geographies.display_name_short)
 	FROM measurements
 	LEFT JOIN measurement_series ON measurement_series.measurement_id = measurements.id
 	LEFT JOIN series ON series.id = measurement_series.series_id
@@ -194,7 +194,7 @@ var siblingsPrefix = `SELECT
 	MAX(measurements.table_prefix), MAX(measurements.table_postfix),
 	MAX(measurements.id), MAX(measurements.data_portal_name),
 	NULL, series.base_year, series.decimals,
-	MAX(fips), SUBSTRING_INDEX(SUBSTR(series.name, LOCATE('@', series.name) + 1), '.', 1) as shandle, MAX(display_name_short)
+	MAX(geographies.fips), MAX(geographies.handle) AS shandle, MAX(geographies.display_name_short)
 	FROM (SELECT measurement_id FROM measurement_series where series_id = ?) as measure
 	LEFT JOIN measurements ON measurements.id = measure.measurement_id
 	LEFT JOIN measurement_series ON measurement_series.measurement_id = measurements.id
@@ -449,7 +449,7 @@ func (r *SeriesRepository) GetFreqByCategory(categoryId int64) (frequencies []mo
 	LEFT JOIN data_list_measurements ON data_list_measurements.data_list_id = categories.data_list_id
 	LEFT JOIN measurement_series ON measurement_series.measurement_id = data_list_measurements.measurement_id
 	LEFT JOIN series ON series.id = measurement_series.series_id
-	LEFT JOIN feature_toggles ON feature_toggles.name = 'filter_by_quarantine'
+	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE categories.id = ?
 	AND NOT categories.hidden
 	AND NOT series.restricted
@@ -621,8 +621,9 @@ func (r *SeriesRepository) GetSeriesById(seriesId int64) (dataPortalSeries model
 	measurements.table_prefix, measurements.table_postfix,
 	measurements.id, measurements.data_portal_name,
 	series.base_year, series.decimals,
-	fips, SUBSTRING_INDEX(SUBSTR(series.name, LOCATE('@', series.name) + 1), '.', 1) as shandle, display_name_short
+	geographies.fips, geographies.handle AS shandle, geographies.display_name_short
 	FROM series
+	JOIN geographies ON geographies.id = series.geography_id
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
 	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
 	LEFT JOIN units ON units.id = series.unit_id

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -587,7 +587,7 @@ func (r *SeriesRepository) GetSeriesSiblingsFreqById(
 	JOIN (SELECT name FROM series WHERE id = ?) as original_series
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE series.universe = 'UHERO'
-	AND TRIM(TRAILING '&' FROM SUBSTRING_INDEX(series.name, '@', 1)) =
+	AND TRIM(TRAILING 'NS' FROM TRIM(TRAILING '&' FROM SUBSTRING_INDEX(series.name, '@', 1))) =
 	    TRIM(TRAILING 'NS' FROM TRIM(TRAILING '&' FROM SUBSTRING_INDEX(original_series.name, '@', 1)))
 	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -584,9 +584,9 @@ func (r *SeriesRepository) GetSeriesSiblingsFreqById(
 ) (frequencyList []models.FrequencyResult, err error) {
 	rows, err := r.DB.Query(`SELECT DISTINCT(RIGHT(series.name, 1)) as freq
 	FROM series
-	JOIN (SELECT name FROM series WHERE id = ?) as original_series
+	JOIN (SELECT name, universe FROM series WHERE id = ?) as original_series
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
-	WHERE series.universe = 'UHERO'
+	WHERE series.universe = original_series.universe
 	AND TRIM(TRAILING 'NS' FROM TRIM(TRAILING '&' FROM SUBSTRING_INDEX(series.name, '@', 1))) =
 	    TRIM(TRAILING 'NS' FROM TRIM(TRAILING '&' FROM SUBSTRING_INDEX(original_series.name, '@', 1)))
 	AND NOT series.restricted

--- a/routers/search.go
+++ b/routers/search.go
@@ -36,6 +36,12 @@ func SetSearchRoutes(
 		"freq", "{freq:[ASQMWDasqmwd]}",
 		"expand", "true",
 	)
+	router.HandleFunc("/v1/search/series", controllers.GetSearchResultByGeoAndFreqAndUniverse(searchRepository, cacheRepository)).Methods("GET").Queries(
+		"q", "{search_text:.+}",
+		"geo", "{geo:[A-Za-z-0-9]+}",
+		"freq", "{freq:[ASQMWDasqmwd]}",
+		"u", "{universe_text:.+}",
+	)
 	router.HandleFunc("/v1/search/series", controllers.GetSearchResultByGeoAndFreq(searchRepository, cacheRepository)).Methods("GET").Queries(
 		"q", "{search_text:.+}",
 		"geo", "{geo:[A-Za-z-0-9]+}",


### PR DESCRIPTION
This stuff needs to be done in rails console:
```
Geography.create(universe: 'DBEDT', fips: '15', display_name: 'State of Hawaii', display_name_short: 'State of Hawaii', handle: 'HI')
Geography.create(universe: 'DBEDT', fips: '15001', display_name: 'Hawaii County', display_name_short: 'Hawaii County', handle: 'HAW')
Geography.create(universe: 'DBEDT', fips: '15003', display_name: 'City and County of Honolulu', display_name_short: 'Honolulu County', handle: 'HON')
Geography.create(universe: 'DBEDT', fips: '15007', display_name: 'Kauai County', display_name_short: 'Kauai County', handle: 'KAU')
Geography.create(universe: 'DBEDT', fips: '15009', display_name: 'Maui County', display_name_short: 'Maui County', handle: 'MAU')
```
Then, this needs to be done in db:
```
update series s
  join geographies g on s.universe = g.universe
                    and g.handle = substring_index(substring_index(s.name, '@', -1), '.', 1)
set s.geography_id = g.id
where s.geography_id is null
```
 
## Testing
Find routes in `routers/search.go` and try each one with different params filled in.
Note that there is no route for a URL such as `/v1/search/series?q=&geo=&freq=&u=`. Wrong results will be returned if you call such an endpoint.
