### PR TITLE
filter out series siblings that have no data

### DIFF
--- a/data/common.go
+++ b/data/common.go
@@ -67,7 +67,7 @@ func getNextSeriesFromRows(rows *sql.Rows) (dataPortalSeries models.DataPortalSe
 		return
 	}
 	dataPortalSeries = models.DataPortalSeries{
-		Id: series.Id,
+		Id:   series.Id,
 		Name: series.Name,
 	}
 	dataPortalSeries.FrequencyShort = dataPortalSeries.Name[len(dataPortalSeries.Name)-1:]
@@ -176,7 +176,7 @@ func getNextSeriesFromRow(row *sql.Row) (dataPortalSeries models.DataPortalSerie
 		return dataPortalSeries, err
 	}
 	dataPortalSeries = models.DataPortalSeries{
-		Id: series.Id,
+		Id:   series.Id,
 		Name: series.Name,
 	}
 	dataPortalSeries.FrequencyShort = dataPortalSeries.Name[len(dataPortalSeries.Name)-1:]
@@ -261,7 +261,8 @@ func getFreqGeoCombinations(r *SeriesRepository, seriesId int64) (
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
 		LEFT JOIN geographies geo on geo.id = series.geography_id
-		WHERE measurement_series.series_id = ?;`, seriesId)
+		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
+		WHERE pdp.value IS NOT NULL AND measurement_series.series_id = ?;`, seriesId)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -184,7 +184,7 @@ var freqFilter = ` AND series.frequency = ? `
 var measurementPostfix = ` GROUP BY series.id;`
 var sortStmt = ` GROUP BY series.id ORDER BY MAX(data_list_measurements.list_order);`
 var siblingsPrefix = `SELECT
-        series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
+    series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
 	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
@@ -199,6 +199,7 @@ var siblingsPrefix = `SELECT
 	LEFT JOIN measurements ON measurements.id = measure.measurement_id
 	LEFT JOIN measurement_series ON measurement_series.measurement_id = measurements.id
 	LEFT JOIN series ON series.id = measurement_series.series_id
+	LEFT JOIN public_data_points ON public_data_points.series_id = series.id
 	LEFT JOIN geographies ON geographies.id = series.geography_id
 	LEFT JOIN units ON units.id = series.unit_id
 	LEFT JOIN units AS measurement_units ON measurement_units.id = measurements.unit_id
@@ -208,6 +209,7 @@ var siblingsPrefix = `SELECT
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE NOT series.restricted
+	AND public_data_points.value IS NOT NULL
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	GROUP BY series.id`
 

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -570,7 +570,10 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdGeoAndFreq(
 ) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(
 		strings.Join([]string{siblingsPrefix, geoFilter, freqFilter, siblingSortStmt}, ""),
-		seriesId, geo, freqDbNames[strings.ToUpper(freq)])
+		seriesId,
+		geo,
+		freqDbNames[strings.ToUpper(freq)],
+	)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The siblings endpoint should now only return series that have data (i.e. Series 159878 exists in udaman, but it has no data.).

/v1/series/siblings?id=159579
In the geoFreq/freqGeos, Japan should only be available at the annual frequency, and the series with id 159878 should no longer appear in the results.