### PR TITLE
Change series observations from objects to arrays of scalar (UA-752)

### DIFF
--- a/data/common.go
+++ b/data/common.go
@@ -67,7 +67,7 @@ func getNextSeriesFromRows(rows *sql.Rows) (dataPortalSeries models.DataPortalSe
 		return
 	}
 	dataPortalSeries = models.DataPortalSeries{
-		Id: series.Id,
+		Id:   series.Id,
 		Name: series.Name,
 	}
 	dataPortalSeries.FrequencyShort = dataPortalSeries.Name[len(dataPortalSeries.Name)-1:]
@@ -176,7 +176,7 @@ func getNextSeriesFromRow(row *sql.Row) (dataPortalSeries models.DataPortalSerie
 		return dataPortalSeries, err
 	}
 	dataPortalSeries = models.DataPortalSeries{
-		Id: series.Id,
+		Id:   series.Id,
 		Name: series.Name,
 	}
 	dataPortalSeries.FrequencyShort = dataPortalSeries.Name[len(dataPortalSeries.Name)-1:]
@@ -261,7 +261,8 @@ func getFreqGeoCombinations(r *SeriesRepository, seriesId int64) (
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
 		LEFT JOIN geographies geo on geo.id = series.geography_id
-		WHERE measurement_series.series_id = ?;`, seriesId)
+		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
+		WHERE pdp.value IS NOT NULL AND measurement_series.series_id = ?;`, seriesId)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -741,9 +741,9 @@ func (r *SeriesRepository) GetTransformation(
 		return
 	}
 	var (
-		observation_dates  []string
-		observation_values []string
-		observation_phist  []bool
+		obsDates	[]string
+		obsValues	[]string
+		obsPseudoHist	[]bool
 	)
 
 	for rows.Next() {
@@ -766,9 +766,9 @@ func (r *SeriesRepository) GetTransformation(
 			observationEnd = observation.Date
 		}
 		// This "magic" date must be used for formatting!
-		observation_dates = append(observation_dates, observation.Date.Format("2006-01-02"))
-		observation_values = append(observation_values, strconv.FormatFloat(observation.Value.Float64, 'f', 5, 64))
-		observation_phist = append(observation_phist, observation.PseudoHistory.Bool)
+		obsDates = append(obsDates, observation.Date.Format("2006-01-02"))
+		obsValues = append(obsValues, strconv.FormatFloat(observation.Value.Float64, 'f', 5, 64))
+		obsPseudoHist = append(obsPseudoHist, observation.PseudoHistory.Bool)
 	}
 	if currentStart.IsZero() || (!observationStart.IsZero() && currentStart.After(observationStart)) {
 		*currentStart = observationStart
@@ -777,8 +777,8 @@ func (r *SeriesRepository) GetTransformation(
 		*currentEnd = observationEnd
 	}
 	transformationResult.Transformation = transformations[transformation].Label
-	transformationResult.ObservationDates = observation_dates
-	transformationResult.ObservationValues = observation_values
-	transformationResult.ObservationPHist = observation_phist
+	transformationResult.ObservationDates = obsDates
+	transformationResult.ObservationValues = obsValues
+	transformationResult.ObservationPHist = obsPseudoHist
 	return
 }

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -767,7 +767,7 @@ func (r *SeriesRepository) GetTransformation(
 		}
 		// This "magic" date must be used for formatting!
 		observation_dates = append(observation_dates, observation.Date.Format("2006-01-02"))
-		observation_values = append(observation_values, strconv.FormatFloat(observation.Value.Float64, 'f', -1, 64))
+		observation_values = append(observation_values, strconv.FormatFloat(observation.Value.Float64, 'f', 5, 64))
 		observation_phist = append(observation_phist, observation.PseudoHistory.Bool)
 	}
 	if currentStart.IsZero() || (!observationStart.IsZero() && currentStart.After(observationStart)) {

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/UHERO/rest-api/models"
+	"strconv"
 )
 
 type SeriesRepository struct {
@@ -741,7 +742,7 @@ func (r *SeriesRepository) GetTransformation(
 	}
 	var (
 		observation_dates  []string
-		observation_values []float64
+		observation_values []string
 		observation_phist  []bool
 	)
 
@@ -766,7 +767,7 @@ func (r *SeriesRepository) GetTransformation(
 		}
 		// This "magic" date must be used for formatting!
 		observation_dates = append(observation_dates, observation.Date.Format("2006-01-02"))
-		observation_values = append(observation_values, observation.Value.Float64)
+		observation_values = append(observation_values, strconv.FormatFloat(observation.Value.Float64, 'f', -1, 64))
 		observation_phist = append(observation_phist, observation.PseudoHistory.Bool)
 	}
 	if currentStart.IsZero() || (!observationStart.IsZero() && currentStart.After(observationStart)) {

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -740,7 +740,9 @@ func (r *SeriesRepository) GetTransformation(
 		return
 	}
 	var (
-		observations []models.DataPortalObservation
+		observation_dates  []string
+		observation_values []float64
+		observation_phist  []bool
 	)
 
 	for rows.Next() {
@@ -769,10 +771,10 @@ func (r *SeriesRepository) GetTransformation(
 		if observation.PseudoHistory.Valid && observation.PseudoHistory.Bool {
 			dataPortalObservation.PseudoHistory = &observation.PseudoHistory.Bool
 		}
-		observations = append(
-			observations,
-			dataPortalObservation,
-		)
+		// This "magic" date must be used for formatting!
+		observation_dates = append(observation_dates, observation.Date.Format("2006-01-02"))
+		observation_values = append(observation_values, observation.Value.Float64)
+		observation_phist = append(observation_phist, observation.PseudoHistory.Bool)
 	}
 	if currentStart.IsZero() || (!observationStart.IsZero() && currentStart.After(observationStart)) {
 		*currentStart = observationStart
@@ -781,6 +783,8 @@ func (r *SeriesRepository) GetTransformation(
 		*currentEnd = observationEnd
 	}
 	transformationResult.Transformation = transformations[transformation].Label
-	transformationResult.Observations = observations
+	transformationResult.ObservationDates = observation_dates
+	transformationResult.ObservationValues = observation_values
+	transformationResult.ObservationPHist = observation_phist
 	return
 }

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -764,13 +764,6 @@ func (r *SeriesRepository) GetTransformation(
 		if observationEnd.IsZero() || observationEnd.Before(observation.Date) {
 			observationEnd = observation.Date
 		}
-		dataPortalObservation := models.DataPortalObservation{
-			Date:  observation.Date,
-			Value: observation.Value.Float64,
-		}
-		if observation.PseudoHistory.Valid && observation.PseudoHistory.Bool {
-			dataPortalObservation.PseudoHistory = &observation.PseudoHistory.Bool
-		}
 		// This "magic" date must be used for formatting!
 		observation_dates = append(observation_dates, observation.Date.Format("2006-01-02"))
 		observation_values = append(observation_values, observation.Value.Float64)

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -183,8 +183,9 @@ var geoFilter = ` AND geographies.handle = UPPER(?) `
 var freqFilter = ` AND series.frequency = ? `
 var measurementPostfix = ` GROUP BY series.id;`
 var sortStmt = ` GROUP BY series.id ORDER BY MAX(data_list_measurements.list_order);`
+var siblingSortStmt = ` GROUP BY series.id;`
 var siblingsPrefix = `SELECT
-        series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
+    series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
 	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
@@ -199,6 +200,7 @@ var siblingsPrefix = `SELECT
 	LEFT JOIN measurements ON measurements.id = measure.measurement_id
 	LEFT JOIN measurement_series ON measurement_series.measurement_id = measurements.id
 	LEFT JOIN series ON series.id = measurement_series.series_id
+	LEFT JOIN public_data_points ON public_data_points.series_id = series.id
 	LEFT JOIN geographies ON geographies.id = series.geography_id
 	LEFT JOIN units ON units.id = series.unit_id
 	LEFT JOIN units AS measurement_units ON measurement_units.id = measurements.unit_id
@@ -208,8 +210,8 @@ var siblingsPrefix = `SELECT
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE NOT series.restricted
-	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
-	GROUP BY series.id`
+	AND public_data_points.value IS NOT NULL
+	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
 
 func (r *SeriesRepository) GetSeriesByGroupAndFreq(
 	groupId int64,
@@ -476,7 +478,10 @@ func (r *SeriesRepository) GetFreqByCategory(categoryId int64) (frequencies []mo
 }
 
 func (r *SeriesRepository) GetSeriesSiblingsById(seriesId int64) (seriesList []models.DataPortalSeries, err error) {
-	rows, err := r.DB.Query(siblingsPrefix, seriesId)
+	rows, err := r.DB.Query(
+		strings.Join([]string{siblingsPrefix, siblingSortStmt}, ""),
+		seriesId,
+	)
 	if err != nil {
 		return
 	}
@@ -502,7 +507,11 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdAndFreq(
 	seriesId int64,
 	freq string,
 ) (seriesList []models.DataPortalSeries, err error) {
-	rows, err := r.DB.Query(strings.Join([]string{siblingsPrefix, freqFilter}, ""), seriesId, freqDbNames[strings.ToUpper(freq)])
+	rows, err := r.DB.Query(strings.Join(
+		[]string{siblingsPrefix, freqFilter, siblingSortStmt}, ""),
+		seriesId,
+		freqDbNames[strings.ToUpper(freq)],
+	)
 	if err != nil {
 		return
 	}
@@ -528,7 +537,11 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdAndGeo(
 	seriesId int64,
 	geo string,
 ) (seriesList []models.DataPortalSeries, err error) {
-	rows, err := r.DB.Query(strings.Join([]string{siblingsPrefix, geoFilter}, ""), seriesId, geo)
+	rows, err := r.DB.Query(
+		strings.Join([]string{siblingsPrefix, geoFilter, siblingSortStmt}, ""),
+		seriesId,
+		geo,
+	)
 	if err != nil {
 		return
 	}
@@ -556,8 +569,11 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdGeoAndFreq(
 	freq string,
 ) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(
-		strings.Join([]string{siblingsPrefix, geoFilter, freqFilter}, ""),
-		seriesId, geo, freqDbNames[strings.ToUpper(freq)])
+		strings.Join([]string{siblingsPrefix, geoFilter, freqFilter, siblingSortStmt}, ""),
+		seriesId,
+		geo,
+		freqDbNames[strings.ToUpper(freq)],
+	)
 	if err != nil {
 		return
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -208,8 +208,10 @@ type SeriesObservations struct {
 }
 
 type TransformationResult struct {
-	Transformation string                  `json:"transformation"`
-	Observations   []DataPortalObservation `json:"observations"`
+	Transformation string        `json:"transformation"`
+	ObservationDates   []string  `json:"observation_dates"`
+	ObservationValues  []float64 `json:"observation_values"`
+	ObservationPHist   []bool    `json:"observation_phistory"`
 }
 
 type Feedback struct {

--- a/models/models.go
+++ b/models/models.go
@@ -209,9 +209,9 @@ type SeriesObservations struct {
 
 type TransformationResult struct {
 	Transformation string        `json:"transformation"`
-	ObservationDates   []string  `json:"observation_dates"`
-	ObservationValues  []string  `json:"observation_values"`
-	ObservationPHist   []bool    `json:"observation_phistory"`
+	ObservationDates   []string  `json:"dates"`
+	ObservationValues  []string  `json:"values"`
+	ObservationPHist   []bool    `json:"pseudoHistory"`
 }
 
 type Feedback struct {

--- a/models/models.go
+++ b/models/models.go
@@ -210,7 +210,7 @@ type SeriesObservations struct {
 type TransformationResult struct {
 	Transformation string        `json:"transformation"`
 	ObservationDates   []string  `json:"observation_dates"`
-	ObservationValues  []float64 `json:"observation_values"`
+	ObservationValues  []string  `json:"observation_values"`
 	ObservationPHist   []bool    `json:"observation_phistory"`
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -191,7 +191,7 @@ type Observation struct {
 	Date          time.Time
 	Value         sql.NullFloat64
 	PseudoHistory sql.NullBool
-	Decimals      int64
+	Decimals      int
 }
 
 type DataPortalObservation struct {

--- a/models/models.go
+++ b/models/models.go
@@ -191,6 +191,7 @@ type Observation struct {
 	Date          time.Time
 	Value         sql.NullFloat64
 	PseudoHistory sql.NullBool
+	Decimals      int64
 }
 
 type DataPortalObservation struct {


### PR DESCRIPTION
_THIS PR SHOULD NOT BE MERGED UNTIL VWARD IS READY WITH FRONTEND CHANGES_

Endpoints that returns lists of series observations change from returning arrays of objects like `{ "date": "2016-01-01", "value": "892.2923" }` to returning three arrays of scalar values: `observation_dates` (of strings), `observation_values` (of strings), and `observation_phistory` (of JSON-native boolean), which are intended to align into data points where array elements in the same ordinal position of each of the three arrays go together. Also, precision of values had been unconstrained, and with this PR it is set to exactly 5 decimal places. Unfortunately, there is no simple way to avoid returning trailing zeroes if there are any, so we accept for now that they are included.

## Testing
Use Postman or equivalent to check output of several endpoints that return expanded series data:
```
http://localhost:8080/v1/series/observations?id=153609
http://localhost:8080/v1/measurement/series?id=74&expand=true
http://localhost:8080/v1/category/series?id=25&expand=true
http://localhost:8080/v1/search/series?q=support&geo=HI&freq=A&expand=true
```
In these examples, transformation **c5ma** sometimes is empty. Where the old `observations` array was null, the three new arrays are null in a case like this.