### PR TITLE
New endpoint /v1/package/series; Series and Categories include Universe member (UA-809)

### DIFF
--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -58,6 +58,11 @@ type (
 		Data models.DataPortalSeries `json:"data"`
 	}
 
+	// GET - /series/view
+	SeriesView struct {
+		Data models.DataPortalSeriesView `json:"data"`
+	}
+
 	// GET - /series/observations
 	ObservationList struct {
 		Data models.SeriesObservations `json:"data"`

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -59,8 +59,8 @@ type (
 	}
 
 	// GET - /series/view
-	SeriesView struct {
-		Data models.DataPortalSeriesView `json:"data"`
+	SeriesPackage struct {
+		Data models.DataPortalSeriesPackage `json:"data"`
 	}
 
 	// GET - /series/observations

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -58,11 +58,6 @@ type (
 		Data models.DataPortalSeries `json:"data"`
 	}
 
-	// GET - /series/view
-	SeriesPackage struct {
-		Data models.DataPortalSeriesPackage `json:"data"`
-	}
-
 	// GET - /series/observations
 	ObservationList struct {
 		Data models.SeriesObservations `json:"data"`
@@ -81,5 +76,10 @@ type (
 	// POST - /feedback
 	FeedbackResource struct {
 		Data models.Feedback `json:"data"`
+	}
+
+	// GET - /package/series
+	SeriesPackage struct {
+		Data models.DataPortalSeriesPackage `json:"data"`
 	}
 )

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -3,11 +3,10 @@ package controllers
 import (
 	"encoding/json"
 	"net/http"
-
 	"github.com/UHERO/rest-api/common"
 	"github.com/UHERO/rest-api/data"
 	"github.com/gorilla/mux"
-	"errors"
+	"github.com/UHERO/rest-api/models"
 )
 
 func GetSeriesByGroupId(
@@ -271,9 +270,9 @@ func GetSeriesObservations(seriesRepository *data.SeriesRepository, cacheReposit
 func GetSeriesView(
 	seriesRepository *data.SeriesRepository,
 	categoryRepository *data.CategoryRepository,
-	cacheRepository *data.CacheRepository) func(http.ResponseWriter, *http.Request) {
+	cacheRepository *data.CacheRepository,
+) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		the_data := nil
 		id, ok := getId(w, r)
 		if !ok {
 			return
@@ -282,7 +281,7 @@ func GetSeriesView(
 		if !ok {
 			universe = "UHERO"
 		}
-		categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
+		_, err := categoryRepository.GetAllCategoriesByUniverse(universe)
 		if err != nil {
 			common.DisplayAppError(
 				w,
@@ -292,7 +291,7 @@ func GetSeriesView(
 			)
 			return
 		}
-		series, err := seriesRepository.GetSeriesById(id)
+		_, err = seriesRepository.GetSeriesById(id)
 		if err != nil {
 			common.DisplayAppError(
 				w,
@@ -302,7 +301,7 @@ func GetSeriesView(
 			)
 			return
 		}
-		seriesObs, err := seriesRepository.GetSeriesObservations(id)
+		_, err = seriesRepository.GetSeriesObservations(id)
 		if err != nil {
 			common.DisplayAppError(
 				w,
@@ -312,7 +311,17 @@ func GetSeriesView(
 			)
 			return
 		}
-		j, err := json.Marshal(the_data)
+		_, err = seriesRepository.GetSeriesSiblingsById(id)
+		if err != nil {
+			common.DisplayAppError(
+				w,
+				err,
+				"An unexpected error has occurred",
+				500,
+			)
+			return
+		}
+		j, err := json.Marshal(&models.DataPortalSeries{}) // Not really this. We'll make a new combined model object
 		if err != nil {
 			common.DisplayAppError(
 				w,

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"github.com/UHERO/rest-api/common"
 	"github.com/UHERO/rest-api/data"
-	"github.com/gorilla/mux"
 	"github.com/UHERO/rest-api/models"
 )
 
@@ -290,7 +289,7 @@ func GetSeriesView(
 		}
 		view.Series = series
 
-		categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
+		categories, err := categoryRepository.GetAllCategoriesByUniverse(series.Universe)
 		if err != nil {
 			common.DisplayAppError(
 				w,

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -265,3 +265,8 @@ func GetSeriesObservations(seriesRepository *data.SeriesRepository, cacheReposit
 		WriteCache(r, cacheRepository, j)
 	}
 }
+
+func GetSeriesView(seriesRepository *data.SeriesRepository, cacheRepository *data.CacheRepository) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+	}
+}

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -273,6 +273,7 @@ func GetSeriesView(
 	cacheRepository *data.CacheRepository,
 ) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		view := models.DataPortalSeriesView{}
 		id, ok := getId(w, r)
 		if !ok {
 			return
@@ -281,7 +282,7 @@ func GetSeriesView(
 		if !ok {
 			universe = "UHERO"
 		}
-		_, err := categoryRepository.GetAllCategoriesByUniverse(universe)
+		categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
 		if err != nil {
 			common.DisplayAppError(
 				w,
@@ -291,7 +292,9 @@ func GetSeriesView(
 			)
 			return
 		}
-		_, err = seriesRepository.GetSeriesById(id)
+		view.Categories = categories
+
+		series, err := seriesRepository.GetSeriesById(id)
 		if err != nil {
 			common.DisplayAppError(
 				w,
@@ -301,7 +304,9 @@ func GetSeriesView(
 			)
 			return
 		}
-		_, err = seriesRepository.GetSeriesObservations(id)
+		view.Series = series
+
+		observations, err := seriesRepository.GetSeriesObservations(id)
 		if err != nil {
 			common.DisplayAppError(
 				w,
@@ -311,7 +316,9 @@ func GetSeriesView(
 			)
 			return
 		}
-		_, err = seriesRepository.GetSeriesSiblingsById(id)
+		view.Observations = observations
+
+		siblings, err := seriesRepository.GetSeriesSiblingsById(id)
 		if err != nil {
 			common.DisplayAppError(
 				w,
@@ -321,7 +328,9 @@ func GetSeriesView(
 			)
 			return
 		}
-		j, err := json.Marshal(&models.DataPortalSeries{}) // Not really this. We'll make a new combined model object
+		view.Siblings = siblings
+
+		j, err := json.Marshal(&view)
 		if err != nil {
 			common.DisplayAppError(
 				w,

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -272,7 +272,7 @@ func GetSeriesPackage(
 	cacheRepository *data.CacheRepository,
 ) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		view := models.DataPortalSeriesPackage{}
+		pkg := models.DataPortalSeriesPackage{}
 		id, ok := getId(w, r)
 		if !ok {
 			return
@@ -287,7 +287,7 @@ func GetSeriesPackage(
 			)
 			return
 		}
-		view.Series = series
+		pkg.Series = series
 
 		categories, err := categoryRepository.GetAllCategoriesByUniverse(series.Universe)
 		if err != nil {
@@ -299,7 +299,7 @@ func GetSeriesPackage(
 			)
 			return
 		}
-		view.Categories = categories
+		pkg.Categories = categories
 
 		observations, err := seriesRepository.GetSeriesObservations(id)
 		if err != nil {
@@ -311,7 +311,7 @@ func GetSeriesPackage(
 			)
 			return
 		}
-		view.Observations = observations
+		pkg.Observations = observations
 
 		siblings, err := seriesRepository.GetSeriesSiblingsById(id)
 		if err != nil {
@@ -323,9 +323,9 @@ func GetSeriesPackage(
 			)
 			return
 		}
-		view.Siblings = siblings
+		pkg.Siblings = siblings
 
-		j, err := json.Marshal(SeriesView{Data: view})
+		j, err := json.Marshal(SeriesPackage{Data: pkg})
 		if err != nil {
 			common.DisplayAppError(
 				w,

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -279,60 +279,35 @@ func GetSeriesPackage(
 		}
 		series, err := seriesRepository.GetSeriesById(id)
 		if err != nil {
-			common.DisplayAppError(
-				w,
-				err,
-				"An unexpected error has occurred",
-				500,
-			)
+			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return
 		}
 		pkg.Series = series
 
 		categories, err := categoryRepository.GetAllCategoriesByUniverse(series.Universe)
 		if err != nil {
-			common.DisplayAppError(
-				w,
-				err,
-				"An unexpected error has occurred",
-				500,
-			)
+			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return
 		}
 		pkg.Categories = categories
 
 		observations, err := seriesRepository.GetSeriesObservations(id)
 		if err != nil {
-			common.DisplayAppError(
-				w,
-				err,
-				"An unexpected error has occurred",
-				500,
-			)
+			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return
 		}
 		pkg.Observations = observations
 
 		siblings, err := seriesRepository.GetSeriesSiblingsById(id)
 		if err != nil {
-			common.DisplayAppError(
-				w,
-				err,
-				"An unexpected error has occurred",
-				500,
-			)
+			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return
 		}
 		pkg.Siblings = siblings
 
 		j, err := json.Marshal(SeriesPackage{Data: pkg})
 		if err != nil {
-			common.DisplayAppError(
-				w,
-				err,
-				"An unexpected error processing JSON has occurred",
-				500,
-			)
+			common.DisplayAppError(w, err, "An unexpected error processing JSON has occurred", 500)
 			return
 		}
 		WriteResponse(w, j)

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -278,22 +278,6 @@ func GetSeriesView(
 		if !ok {
 			return
 		}
-		universe, ok := mux.Vars(r)["universe_text"]
-		if !ok {
-			universe = "UHERO"
-		}
-		categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
-		if err != nil {
-			common.DisplayAppError(
-				w,
-				err,
-				"An unexpected error has occurred",
-				500,
-			)
-			return
-		}
-		view.Categories = categories
-
 		series, err := seriesRepository.GetSeriesById(id)
 		if err != nil {
 			common.DisplayAppError(
@@ -305,6 +289,18 @@ func GetSeriesView(
 			return
 		}
 		view.Series = series
+
+		categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
+		if err != nil {
+			common.DisplayAppError(
+				w,
+				err,
+				"An unexpected error has occurred",
+				500,
+			)
+			return
+		}
+		view.Categories = categories
 
 		observations, err := seriesRepository.GetSeriesObservations(id)
 		if err != nil {

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -325,7 +325,7 @@ func GetSeriesView(
 		}
 		view.Siblings = siblings
 
-		j, err := json.Marshal(&view)
+		j, err := json.Marshal(SeriesView{Data: view})
 		if err != nil {
 			common.DisplayAppError(
 				w,

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -266,13 +266,13 @@ func GetSeriesObservations(seriesRepository *data.SeriesRepository, cacheReposit
 	}
 }
 
-func GetSeriesView(
+func GetSeriesPackage(
 	seriesRepository *data.SeriesRepository,
 	categoryRepository *data.CategoryRepository,
 	cacheRepository *data.CacheRepository,
 ) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		view := models.DataPortalSeriesView{}
+		view := models.DataPortalSeriesPackage{}
 		id, ok := getId(w, r)
 		if !ok {
 			return

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -22,6 +22,7 @@ func (r *CategoryRepository) GetAllCategoriesByUniverse(universe string) (catego
 	rows, err := r.DB.Query(
 		`SELECT categories.id,
 			ANY_VALUE(categories.name) AS catname,
+			ANY_VALUE(categories.universe) AS universe,
 			ANY_VALUE(categories.ancestry) AS ancest,
 			categories.default_freq AS catfreq,
 			ANY_VALUE(geographies.handle) AS catgeo,
@@ -53,6 +54,7 @@ func (r *CategoryRepository) GetAllCategoriesByUniverse(universe string) (catego
 		err = rows.Scan(
 			&category.Id,
 			&category.Name,
+			&category.Universe,
 			&category.Ancestry,
 			&category.DefaultFrequency,
 			&category.DefaultGeoHandle,
@@ -70,6 +72,7 @@ func (r *CategoryRepository) GetAllCategoriesByUniverse(universe string) (catego
 		dataPortalCategory := models.Category{
 			Id:       category.Id,
 			Name:     category.Name,
+			Universe: category.Universe,
 			ParentId: parentId,
 		}
 		if category.DefaultFrequency.Valid || category.DefaultGeoHandle.Valid || category.ObservationStart.Valid || category.ObservationEnd.Valid {
@@ -120,7 +123,7 @@ func getParentId(ancestry sql.NullString) (parentId int64) {
 }
 
 func (r *CategoryRepository) GetCategoryRoots() (categories []models.Category, err error) {
-	rows, err := r.DB.Query(`SELECT id, name FROM categories
+	rows, err := r.DB.Query(`SELECT id, name, universe FROM categories
 				WHERE ancestry IS NULL
 				AND NOT hidden
 				ORDER BY list_order;`)
@@ -132,6 +135,7 @@ func (r *CategoryRepository) GetCategoryRoots() (categories []models.Category, e
 		err = rows.Scan(
 			&category.Id,
 			&category.Name,
+			&category.Universe,
 		)
 		if err != nil {
 			return
@@ -150,6 +154,7 @@ func (r *CategoryRepository) GetCategoryByIdGeoFreq(id int64, originGeo string, 
 	rows, err := r.DB.Query(
 		`SELECT categories.id,
 			ANY_VALUE(categories.name) AS catname,
+			ANY_VALUE(categories.universe) AS universe,
 			ANY_VALUE(parentcat.id) AS parent_id,
 			ANY_VALUE(COALESCE(mygeo.handle, parentgeo.handle)) AS def_geo,
 			ANY_VALUE(COALESCE(categories.default_freq, parentcat.default_freq)) AS def_freq,
@@ -187,6 +192,7 @@ func (r *CategoryRepository) GetCategoryByIdGeoFreq(id int64, originGeo string, 
 		err = rows.Scan(
 			&category.Id,
 			&category.Name,
+			&category.Universe,
 			&category.ParentId,
 			&category.DefaultGeoHandle,
 			&category.DefaultFrequency,
@@ -202,6 +208,7 @@ func (r *CategoryRepository) GetCategoryByIdGeoFreq(id int64, originGeo string, 
 			// Store Category-level information
 			dataPortalCategory.Id = category.Id
 			dataPortalCategory.Name = category.Name
+			dataPortalCategory.Universe = category.Universe
 			if category.ParentId.Valid {
 				dataPortalCategory.ParentId = category.ParentId.Int64
 			}
@@ -266,7 +273,7 @@ func (r *CategoryRepository) GetCategoryByIdGeoFreq(id int64, originGeo string, 
 
 func (r *CategoryRepository) GetCategoriesByName(name string) (categories []models.Category, err error) {
 	fuzzyString := "%" + name + "%"
-	rows, err := r.DB.Query(`SELECT id, name, ancestry FROM categories
+	rows, err := r.DB.Query(`SELECT id, name, universe, ancestry FROM categories
 							 WHERE LOWER(name) LIKE ? AND NOT hidden
 							 ORDER BY list_order;`, fuzzyString)
 	if err != nil {
@@ -277,6 +284,7 @@ func (r *CategoryRepository) GetCategoriesByName(name string) (categories []mode
 		err = rows.Scan(
 			&category.Id,
 			&category.Name,
+			&category.Universe,
 			&category.Ancestry,
 		)
 		if err != nil {
@@ -286,30 +294,9 @@ func (r *CategoryRepository) GetCategoriesByName(name string) (categories []mode
 		categories = append(categories, models.Category{
 			Id:       category.Id,
 			Name:     category.Name,
+			Universe: category.Universe,
 			ParentId: parentId,
 		})
-	}
-	return
-}
-
-func (r *CategoryRepository) GetChildrenOf(id int64) (categories []models.Category, err error) {
-	rows, err := r.DB.Query(`SELECT id, name, parent_id FROM categories
-							 WHERE parent_id = ? AND NOT hidden
-							 ORDER BY list_order;`, id)
-	if err != nil {
-		return
-	}
-	for rows.Next() {
-		category := models.Category{}
-		err = rows.Scan(
-			&category.Id,
-			&category.Name,
-			&category.ParentId,
-		)
-		if err != nil {
-			return
-		}
-		categories = append(categories, category)
 	}
 	return
 }

--- a/data/categoryRepository_test.go
+++ b/data/categoryRepository_test.go
@@ -24,9 +24,9 @@ func TestGetAllCategories(t *testing.T) {
 		Name:     "Income",
 		Ancestry: sql.NullString{Valid: true, String: "1"},
 	}
-	categoryResult := sqlmock.NewRows([]string{"id", "name", "ancestry", "freq", "geo", "fips", "gname", "gshort", "obsStart", "obsEnd"}).
-		AddRow(category1.Id, category1.Name, nil, "A", "HI", nil, nil, nil, nil, nil).
-		AddRow(category2.Id, category2.Name, category2.Ancestry.String, nil, nil, nil, nil, nil, nil, nil)
+	categoryResult := sqlmock.NewRows([]string{"id", "name", "universe", "ancestry", "freq", "geo", "fips", "gname", "gshort", "obsStart", "obsEnd"}).
+		AddRow(category1.Id, category1.Name, "UHERO", nil, "A", "HI", nil, nil, nil, nil, nil).
+		AddRow(category2.Id, category2.Name, "UHERO", category2.Ancestry.String, nil, nil, nil, nil, nil, nil, nil)
 	mock.ExpectQuery("SELECT (.+)").
 		WillReturnRows(categoryResult)
 

--- a/data/common.go
+++ b/data/common.go
@@ -39,6 +39,7 @@ func getNextSeriesFromRows(rows *sql.Rows) (dataPortalSeries models.DataPortalSe
 	err = rows.Scan(
 		&series.Id,
 		&series.Name,
+		&series.Universe,
 		&series.Description,
 		&series.Frequency,
 		&series.SeasonallyAdjusted,
@@ -69,6 +70,7 @@ func getNextSeriesFromRows(rows *sql.Rows) (dataPortalSeries models.DataPortalSe
 	dataPortalSeries = models.DataPortalSeries{
 		Id:   series.Id,
 		Name: series.Name,
+		Universe: series.Universe,
 	}
 	dataPortalSeries.FrequencyShort = dataPortalSeries.Name[len(dataPortalSeries.Name)-1:]
 	dataPortalSeries.Frequency = freqLabel[dataPortalSeries.FrequencyShort]

--- a/data/search.go
+++ b/data/search.go
@@ -10,7 +10,7 @@ import (
 
 func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, universeText string) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(`SELECT
-	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
+	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
 	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
@@ -202,7 +202,7 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreqAndUniverse(
 	universeText string,
 ) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(`SELECT
-	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
+	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
 	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
@@ -278,7 +278,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	universeText string,
 ) (seriesList []models.InflatedSeries, err error) {
 	rows, err := r.DB.Query(`SELECT DISTINCT
-	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
+	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
 	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -130,7 +130,7 @@ var transformations map[string]transformation = map[string]transformation{
 }
 
 var seriesPrefix = `SELECT
-	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
+	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
 	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
@@ -159,7 +159,7 @@ var seriesPrefix = `SELECT
 	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
 var measurementSeriesPrefix = `SELECT
-	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
+	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
 	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
@@ -189,7 +189,7 @@ var measurementPostfix = ` GROUP BY series.id;`
 var sortStmt = ` GROUP BY series.id ORDER BY MAX(data_list_measurements.list_order);`
 var siblingSortStmt = ` GROUP BY series.id;`
 var siblingsPrefix = `SELECT
-    series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
+    series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
 	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,
@@ -613,7 +613,7 @@ func (r *SeriesRepository) GetSeriesSiblingsFreqById(
 
 func (r *SeriesRepository) GetSeriesById(seriesId int64) (dataPortalSeries models.DataPortalSeries, err error) {
 	row, err := r.DB.Query(`SELECT DISTINCT
-	series.id, series.name, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
+	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(measurement_units.long_label, '')),
 	COALESCE(NULLIF(units.short_label, ''), NULLIF(measurement_units.short_label, '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), measurements.data_portal_name), series.percent, series.real,

--- a/models/models.go
+++ b/models/models.go
@@ -128,6 +128,7 @@ func (a ByGeography) Less(i, j int) bool {
 type Series struct {
 	Id                 int64
 	Name               string
+	Universe	   string
 	Description        sql.NullString
 	Frequency          sql.NullString
 	SeasonallyAdjusted sql.NullBool
@@ -165,6 +166,7 @@ type DataPortalSeriesView struct {
 type DataPortalSeries struct {
 	Id                          int64                   `json:"id"`
 	Name                        string                  `json:"name"`
+	Universe		    string                  `json:"universe,omitempty"`
 	Title                       string                  `json:"title,omitempty"`
 	Description                 string                  `json:"description,omitempty"`
 	MeasurementId               int64                   `json:"measurementId,omitempty"`

--- a/models/models.go
+++ b/models/models.go
@@ -18,6 +18,7 @@ type Application struct {
 type Category struct {
 	Id                   int64                   `json:"id"`
 	Name                 string                  `json:"name"`
+	Universe             string                  `json:"universe"`
 	ParentId             int64                   `json:"parentId,omitempty"`
 	Defaults	     *CategoryDefaults	     `json:"defaults,omitempty"`
 	Current		     *CurrentGeoFreq	     `json:"current,omitempty"`
@@ -44,6 +45,7 @@ type CurrentGeoFreq struct {
 type CategoryWithAncestry struct {
 	Id			int64
 	Name			string
+	Universe		string
 	Ancestry		sql.NullString
 	ParentId		sql.NullInt64
 	DefaultGeoHandle	sql.NullString

--- a/models/models.go
+++ b/models/models.go
@@ -159,8 +159,8 @@ type Measurement struct {
 }
 
 type DataPortalSeriesView struct {
-	Categories	[]Category		`json:"categories"`
 	Series		DataPortalSeries	`json:"series"`
+	Categories	[]Category		`json:"categories"`
 	Observations	SeriesObservations	`json:"observations"`
 	Siblings	[]DataPortalSeries	`json:"siblings"`
 }
@@ -168,7 +168,7 @@ type DataPortalSeriesView struct {
 type DataPortalSeries struct {
 	Id                          int64                   `json:"id"`
 	Name                        string                  `json:"name"`
-	Universe		    string                  `json:"universe,omitempty"`
+	Universe		    string                  `json:"universe"`
 	Title                       string                  `json:"title,omitempty"`
 	Description                 string                  `json:"description,omitempty"`
 	MeasurementId               int64                   `json:"measurementId,omitempty"`

--- a/models/models.go
+++ b/models/models.go
@@ -155,6 +155,13 @@ type Measurement struct {
 	Indent int    `json:"indent,omitempty"`
 }
 
+type DataPortalSeriesView struct {
+	Categories	[]Category		`json:"categories"`
+	Series		DataPortalSeries	`json:"series"`
+	Observations	SeriesObservations	`json:"observations"`
+	Siblings	[]DataPortalSeries	`json:"siblings"`
+}
+
 type DataPortalSeries struct {
 	Id                          int64                   `json:"id"`
 	Name                        string                  `json:"name"`

--- a/models/models.go
+++ b/models/models.go
@@ -158,7 +158,7 @@ type Measurement struct {
 	Indent int    `json:"indent,omitempty"`
 }
 
-type DataPortalSeriesView struct {
+type DataPortalSeriesPackage struct {
 	Series		DataPortalSeries	`json:"series"`
 	Categories	[]Category		`json:"categories"`
 	Observations	SeriesObservations	`json:"observations"`

--- a/routers/package.go
+++ b/routers/package.go
@@ -1,0 +1,21 @@
+package routers
+
+import (
+	"github.com/UHERO/rest-api/controllers"
+	"github.com/UHERO/rest-api/data"
+	"github.com/gorilla/mux"
+)
+
+func SetPackageRoutes(
+	router *mux.Router,
+	seriesRepository *data.SeriesRepository,
+	categoryRepository *data.CategoryRepository,
+	cacheRepository *data.CacheRepository,
+) *mux.Router {
+	router.HandleFunc(
+		"/v1/package/series",
+		controllers.GetSeriesPackage(seriesRepository, categoryRepository, cacheRepository),
+	).Methods("GET").Queries(
+		"id", "{id:[0-9]+}",
+	)
+}

--- a/routers/package.go
+++ b/routers/package.go
@@ -18,4 +18,5 @@ func SetPackageRoutes(
 	).Methods("GET").Queries(
 		"id", "{id:[0-9]+}",
 	)
+	return router
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -21,7 +21,7 @@ func InitRoutes(
 
 	apiRouter := mux.NewRouter().StrictSlash(false)
 	apiRouter = SetCategoryRoutes(apiRouter, categoryRepository, seriesRepository, measurementRepository, cacheRepository)
-	apiRouter = SetSeriesRoutes(apiRouter, seriesRepository, cacheRepository)
+	apiRouter = SetSeriesRoutes(apiRouter, seriesRepository, categoryRepository, cacheRepository)
 	apiRouter = SetMeasurementRoutes(apiRouter, seriesRepository, cacheRepository)
 	apiRouter = SetSearchRoutes(apiRouter, seriesRepository, cacheRepository)
 	apiRouter = SetGeographyRoutes(apiRouter, geographyRepository, cacheRepository)

--- a/routers/router.go
+++ b/routers/router.go
@@ -21,7 +21,7 @@ func InitRoutes(
 
 	apiRouter := mux.NewRouter().StrictSlash(false)
 	apiRouter = SetCategoryRoutes(apiRouter, categoryRepository, seriesRepository, measurementRepository, cacheRepository)
-	apiRouter = SetSeriesRoutes(apiRouter, seriesRepository, categoryRepository, cacheRepository)
+	apiRouter = SetSeriesRoutes(apiRouter, seriesRepository, cacheRepository)
 	apiRouter = SetMeasurementRoutes(apiRouter, seriesRepository, cacheRepository)
 	apiRouter = SetSearchRoutes(apiRouter, seriesRepository, cacheRepository)
 	apiRouter = SetGeographyRoutes(apiRouter, geographyRepository, cacheRepository)

--- a/routers/router.go
+++ b/routers/router.go
@@ -26,6 +26,7 @@ func InitRoutes(
 	apiRouter = SetSearchRoutes(apiRouter, seriesRepository, cacheRepository)
 	apiRouter = SetGeographyRoutes(apiRouter, geographyRepository, cacheRepository)
 	apiRouter = SetFeedbackRoutes(apiRouter, feedbackRepository)
+	apiRouter = SetPackageRoutes(apiRouter, seriesRepository, categoryRepository, cacheRepository)
 
 	router.PathPrefix("/v1").Handler(negroni.New(
 		negroni.HandlerFunc(controllers.CORSOptionsHandler),

--- a/routers/series.go
+++ b/routers/series.go
@@ -36,5 +36,8 @@ func SetSeriesRoutes(
 	router.HandleFunc("/v1/series/observations", controllers.GetSeriesObservations(seriesRepository, cacheRepository)).Methods("GET").Queries(
 		"id", "{id:[0-9]+}",
 	)
+	router.HandleFunc("/v1/series/view", controllers.GetSeriesView(seriesRepository, cacheRepository)).Methods("GET").Queries(
+		"id", "{id:[0-9]+}",
+	)
 	return router
 }

--- a/routers/series.go
+++ b/routers/series.go
@@ -37,8 +37,5 @@ func SetSeriesRoutes(
 	router.HandleFunc("/v1/series/observations", controllers.GetSeriesObservations(seriesRepository, cacheRepository)).Methods("GET").Queries(
 		"id", "{id:[0-9]+}",
 	)
-	router.HandleFunc("/v1/series/view", controllers.GetSeriesView(seriesRepository, categoryRepository, cacheRepository)).Methods("GET").Queries(
-		"id", "{id:[0-9]+}",
-	)
 	return router
 }

--- a/routers/series.go
+++ b/routers/series.go
@@ -9,7 +9,6 @@ import (
 func SetSeriesRoutes(
 	router *mux.Router,
 	seriesRepository *data.SeriesRepository,
-	categoryRepository *data.CategoryRepository,
 	cacheRepository *data.CacheRepository,
 ) *mux.Router {
 	router.HandleFunc("/v1/series", controllers.GetSeriesById(seriesRepository, cacheRepository)).Methods("GET").Queries(

--- a/routers/series.go
+++ b/routers/series.go
@@ -9,6 +9,7 @@ import (
 func SetSeriesRoutes(
 	router *mux.Router,
 	seriesRepository *data.SeriesRepository,
+	categoryRepository *data.CategoryRepository,
 	cacheRepository *data.CacheRepository,
 ) *mux.Router {
 	router.HandleFunc("/v1/series", controllers.GetSeriesById(seriesRepository, cacheRepository)).Methods("GET").Queries(
@@ -36,7 +37,7 @@ func SetSeriesRoutes(
 	router.HandleFunc("/v1/series/observations", controllers.GetSeriesObservations(seriesRepository, cacheRepository)).Methods("GET").Queries(
 		"id", "{id:[0-9]+}",
 	)
-	router.HandleFunc("/v1/series/view", controllers.GetSeriesView(seriesRepository, cacheRepository)).Methods("GET").Queries(
+	router.HandleFunc("/v1/series/view", controllers.GetSeriesView(seriesRepository, categoryRepository, cacheRepository)).Methods("GET").Queries(
 		"id", "{id:[0-9]+}",
 	)
 	return router


### PR DESCRIPTION
New endpoint `/v1/package/series?id=` returns all the data needed for single series view on the data portals, including all categories for that series' universe, its observations, and siblings.

Separately, all Series and Category resources returned by the API now include `universe` as a member field.

New endpoint is not used in data portals yet, so can only be tested by direct API access (using Postman or whatever). Inclusion of `universe` field in output of many endpoints can be tested by observing direct API access, and that it doesn't break anything by running all portals against this branch. I have done so, fairly thoroughly for UHERO and NTA, and found no problems.

Method `data.GetChildrenOf` has been removed because it is not used (for quite a while, it seems).