### PR TITLE
New endpoint /v1/package/category (UA-808)

### DIFF
--- a/controllers/categoryController.go
+++ b/controllers/categoryController.go
@@ -273,7 +273,7 @@ func GetCategoryPackage(
 			return
 		}
 		var universe string
-		for kidId := range kids {
+		for _, kidId := range kids {
 			inflatedCat := models.InflatedCategoryAndSeries{}
 			category, err := categoryRepository.GetCategoryById(kidId)
 			if err != nil {

--- a/controllers/categoryController.go
+++ b/controllers/categoryController.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"github.com/UHERO/rest-api/common"
 	"github.com/UHERO/rest-api/data"
+	"github.com/UHERO/rest-api/models"
 	"github.com/gorilla/mux"
 	"strconv"
-	"github.com/UHERO/rest-api/models"
 )
 
 func GetCategory(categoryRepository *data.CategoryRepository, c *data.CacheRepository) func(http.ResponseWriter, *http.Request) {

--- a/controllers/categoryController.go
+++ b/controllers/categoryController.go
@@ -262,7 +262,7 @@ func GetCategoryView(
 	cacheRepository *data.CacheRepository,
 ) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		view := models.DataPortalCategoryView{}
+		pkg := models.CategoryPackage{}
 		id, geoHandle, freq, ok := getIdGeoAndFreq(w, r)
 		if !ok {
 			return
@@ -279,23 +279,23 @@ func GetCategoryView(
 				common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 				return
 			}
-			universe = category.Universe
+			pkg.ChildCategories = append(pkg.ChildCategories, category)
 			seriesList, err := seriesRepository.GetInflatedSeriesByGroupGeoAndFreq(id, geoHandle, freq, data.Category)
 			if err != nil {
 				common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 				return
 			}
-			view.InflatedSeries = seriesList
-			// then shove it in the view or something
+			pkg.InflatedSeries = seriesList
+			universe = category.Universe
 		}
 		categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
 		if err != nil {
 			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return
 		}
-		view.Categories = categories
+		pkg.Categories = categories
 
-		j, err := json.Marshal(CategoryView{Data: view})
+		j, err := json.Marshal(Categ{Data: view})
 		if err != nil {
 			common.DisplayAppError(w, err, "An unexpected error processing JSON has occurred", 500)
 			return

--- a/controllers/categoryController.go
+++ b/controllers/categoryController.go
@@ -274,7 +274,7 @@ func GetCategoryPackage(
 		}
 		var universe string
 		for _, kidId := range kids {
-			inflatedCat := models.InflatedCategoryAndSeries{}
+			inflatedCat := models.CategoryWithInflatedSeries{}
 			category, err := categoryRepository.GetCategoryById(kidId)
 			if err != nil {
 				common.DisplayAppError(w, err, "An unexpected error has occurred", 500)

--- a/controllers/categoryController.go
+++ b/controllers/categoryController.go
@@ -231,10 +231,10 @@ func GetCategoriesByUniverse(categoryRepository *data.CategoryRepository, c *dat
 			ok = false
 			return
 		}
-		catType := mux.Vars(r)["type"]
 		var categories []models.Category
 		var err error
-		if catType == "nav" {
+		catType, gotType := mux.Vars(r)["type_text"]
+		if gotType && catType == "nav" {
 			categories, err = categoryRepository.GetNavCategoriesByUniverse(universe)
 			if err != nil {
 				common.DisplayAppError(w, err, "An unexpected error has occurred", 500)

--- a/controllers/categoryController.go
+++ b/controllers/categoryController.go
@@ -289,15 +289,15 @@ func GetCategoryPackage(
 			}
 			inflatedCat.Series = seriesList
 
-			pkg.ChildCategories = append(pkg.ChildCategories, inflatedCat)
+			pkg.Children = append(pkg.Children, inflatedCat)
 			universe = category.Universe
 		}
-		categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
+		navCats, err := categoryRepository.GetNavCategories(universe)
 		if err != nil {
 			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return
 		}
-		pkg.AllCategories = categories
+		pkg.NavCategories = navCats
 
 		j, err := json.Marshal(CategoryPackage{Data: pkg})
 		if err != nil {

--- a/controllers/categoryController.go
+++ b/controllers/categoryController.go
@@ -282,7 +282,7 @@ func GetCategoryPackage(
 			}
 			inflatedCat.Category = category
 
-			seriesList, err := seriesRepository.GetInflatedSeriesByGroupGeoAndFreq(id, geoHandle, freq, data.Category)
+			seriesList, err := seriesRepository.GetInflatedSeriesByGroupGeoAndFreq(kidId, geoHandle, freq, data.Category)
 			if err != nil {
 				common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 				return

--- a/controllers/categoryController.go
+++ b/controllers/categoryController.go
@@ -268,6 +268,17 @@ cacheRepository *data.CacheRepository,
 			return
 		}
 		// Find universe, and child cats by category_id
+		kids, err := categoryRepository.GetChildrenOf(id)
+		if err != nil {
+			common.DisplayAppError(
+				w,
+				err,
+				"An unexpected error has occurred",
+				500,
+			)
+			return
+		}
+		for
 		categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
 		if err != nil {
 			common.DisplayAppError(

--- a/controllers/categoryController.go
+++ b/controllers/categoryController.go
@@ -9,6 +9,7 @@ import (
 	"github.com/UHERO/rest-api/data"
 	"github.com/gorilla/mux"
 	"strconv"
+	"github.com/UHERO/rest-api/models"
 )
 
 func GetCategory(categoryRepository *data.CategoryRepository, c *data.CacheRepository) func(http.ResponseWriter, *http.Request) {
@@ -252,5 +253,44 @@ func GetCategoriesByUniverse(categoryRepository *data.CategoryRepository, c *dat
 		}
 		WriteResponse(w, j)
 		WriteCache(r, c, j)
+	}
+}
+
+func GetCategoryView(
+categoryRepository *data.CategoryRepository,
+seriesRepository *data.SeriesRepository,
+cacheRepository *data.CacheRepository,
+) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		view := models.DataPortalCategoryView{}
+		id, ok := getId(w, r)
+		if !ok {
+			return
+		}
+		// Find universe, and child cats by category_id
+		categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
+		if err != nil {
+			common.DisplayAppError(
+				w,
+				err,
+				"An unexpected error has occurred",
+				500,
+			)
+			return
+		}
+		view.Categories = categories
+
+		j, err := json.Marshal(CategoryView{Data: view})
+		if err != nil {
+			common.DisplayAppError(
+				w,
+				err,
+				"An unexpected error processing JSON has occurred",
+				500,
+			)
+			return
+		}
+		WriteResponse(w, j)
+		WriteCache(r, cacheRepository, j)
 	}
 }

--- a/controllers/categoryController.go
+++ b/controllers/categoryController.go
@@ -270,35 +270,29 @@ cacheRepository *data.CacheRepository,
 		// Find universe, and child cats by category_id
 		kids, err := categoryRepository.GetChildrenOf(id)
 		if err != nil {
-			common.DisplayAppError(
-				w,
-				err,
-				"An unexpected error has occurred",
-				500,
-			)
+			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return
 		}
-		for
+		var universe string
+		for kid_id := range kids {
+			category, err := categoryRepository.GetCategoryById(kid_id)
+			if err != nil {
+				common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
+				return
+			}
+			universe = category.Universe
+			// add category to view
+		}
 		categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
 		if err != nil {
-			common.DisplayAppError(
-				w,
-				err,
-				"An unexpected error has occurred",
-				500,
-			)
+			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return
 		}
 		view.Categories = categories
 
 		j, err := json.Marshal(CategoryView{Data: view})
 		if err != nil {
-			common.DisplayAppError(
-				w,
-				err,
-				"An unexpected error processing JSON has occurred",
-				500,
-			)
+			common.DisplayAppError(w, err, "An unexpected error processing JSON has occurred", 500)
 			return
 		}
 		WriteResponse(w, j)

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -31,8 +31,8 @@ type (
 	}
 
 	// GET - /category/view
-	CategoryView struct {
-		Data models.DataPortalCategoryView `json:"data"`
+	CategoryPackage struct {
+		Data models.DataPortalCategoryPackage `json:"data"`
 	}
 
 	// GET - /category

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -30,7 +30,7 @@ type (
 		Data models.Category `json:"data"`
 	}
 
-	// GET - /category/view
+	// GET - /package/category
 	CategoryPackage struct {
 		Data models.DataPortalCategoryPackage `json:"data"`
 	}

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -30,6 +30,11 @@ type (
 		Data models.Category `json:"data"`
 	}
 
+	// GET - /category/view
+	CategoryView struct {
+		Data models.DataPortalCategoryView `json:"data"`
+	}
+
 	// GET - /category
 	CategoriesResource struct {
 		Data []models.Category `json:"data"`

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -7,10 +7,87 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"github.com/UHERO/rest-api/common"
 )
 
 type CategoryRepository struct {
 	DB *sql.DB
+}
+
+func (r *CategoryRepository) GetNavCategories() (categories []models.Category, err error) {
+	categories, err = r.GetNavCategoriesByUniverse("UHERO")
+	return
+}
+func (r *CategoryRepository) GetNavCategoriesByUniverse(universe string) (categories []models.Category, err error) {
+	rows, err := r.DB.Query(
+		`SELECT categories.id,
+			categories.name,
+			categories.universe,
+			categories.ancestry,
+			categories.default_freq AS catfreq,
+			geographies.handle AS catgeo,
+			geographies.fips AS catgeofips,
+			geographies.display_name AS catgeoname,
+			geographies.display_name_short AS catgeonameshort
+		FROM categories
+		LEFT JOIN geographies ON geographies.id = categories.default_geo_id
+		WHERE NOT categories.hidden
+		AND categories.ancestry = CONVERT(
+			(SELECT id from categories WHERE universe = ? AND ancestry IS NULL), CHAR)
+		ORDER BY categories.list_order;`, universe)
+	if err != nil {
+		return
+	}
+	for rows.Next() {
+		category := models.CategoryWithAncestry{}
+		err = rows.Scan(
+			&category.Id,
+			&category.Name,
+			&category.Universe,
+			&category.Ancestry,
+			&category.DefaultFrequency,
+			&category.DefaultGeoHandle,
+			&category.DefaultGeoFIPS,
+			&category.DefaultGeoName,
+			&category.DefaultGeoShortName,
+		)
+		if err != nil {
+			return
+		}
+		parentId := getParentId(category.Ancestry)
+		dataPortalCategory := models.Category{
+			Id:       category.Id,
+			Name:     category.Name,
+			Universe: category.Universe,
+			ParentId: parentId,
+		}
+		if category.DefaultFrequency.Valid || category.DefaultGeoHandle.Valid {
+			// Only initialize Defaults struct if any defaults values are available
+			dataPortalCategory.Defaults = &models.CategoryDefaults{}
+		}
+		if category.DefaultFrequency.Valid {
+			dataPortalCategory.Defaults.Frequency = &models.DataPortalFrequency{
+				Freq: category.DefaultFrequency.String,
+				Label: freqLabel[category.DefaultFrequency.String],
+			}
+		}
+		if category.DefaultGeoHandle.Valid {
+			dataPortalCategory.Defaults.Geography = &models.DataPortalGeography{
+				Handle: category.DefaultGeoHandle.String,
+			}
+			if category.DefaultGeoFIPS.Valid {
+				dataPortalCategory.Defaults.Geography.FIPS = category.DefaultGeoFIPS.String
+			}
+			if category.DefaultGeoName.Valid {
+				dataPortalCategory.Defaults.Geography.Name = category.DefaultGeoName.String
+			}
+			if category.DefaultGeoShortName.Valid {
+				dataPortalCategory.Defaults.Geography.ShortName = category.DefaultGeoShortName.String
+			}
+		}
+		categories = append(categories, dataPortalCategory)
+	}
+	return
 }
 
 func (r *CategoryRepository) GetAllCategories() (categories []models.Category, err error) {
@@ -301,27 +378,6 @@ func (r *CategoryRepository) GetCategoriesByName(name string) (categories []mode
 	return
 }
 
-func (r *CategoryRepository) GetNavCategories(universe string) (children []int64, err error) {
-	rows, err := r.DB.Query(`SELECT id FROM categories
-	                         WHERE SUBSTRING_INDEX(ancestry, '/', -1) = (
-	                         	SELECT id FROM categories WHERE universe = ? AND ancestry IS NULL
-	                         )
-	                         AND NOT hidden
-	                         ORDER BY list_order;`, universe)
-	if err != nil {
-		return
-	}
-	for rows.Next() {
-		var childId int64
-		err = rows.Scan(&childId)
-		if err != nil {
-			return
-		}
-		children = append(children, childId)
-	}
-	return
-}
-
 func (r *CategoryRepository) GetChildrenOf(id int64) (children []int64, err error) {
 	rows, err := r.DB.Query(`SELECT id FROM categories
 	                         WHERE SUBSTRING_INDEX(ancestry, '/', -1) = ?
@@ -337,5 +393,40 @@ func (r *CategoryRepository) GetChildrenOf(id int64) (children []int64, err erro
 		}
 		children = append(children, childId)
 	}
+	return
+}
+
+func (r *CategoryRepository) CreateCategoryPackage(id int64, geoHandle string, freq string) (pkg models.DataPortalCategoryPackage, err error) {
+	kids, err := r.GetChildrenOf(id)
+	if err != nil {
+
+		return
+	}
+	var universe string
+	for _, kidId := range kids {
+		inflatedCat := models.CategoryWithInflatedSeries{}
+		category, err := r.GetCategoryById(kidId)
+		if err != nil {
+			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
+			return
+		}
+		inflatedCat.Category = category
+
+		seriesList, err := seriesRepository.GetInflatedSeriesByGroupGeoAndFreq(kidId, geoHandle, freq, Category)
+		if err != nil {
+			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
+			return
+		}
+		inflatedCat.Series = seriesList
+
+		pkg.Children = append(pkg.Children, inflatedCat)
+		universe = category.Universe
+	}
+	navCats, err := r.GetNavCategoriesByUniverse(universe)
+	if err != nil {
+		common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
+		return
+	}
+	pkg.NavCategories = navCats
 	return
 }

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -301,6 +301,27 @@ func (r *CategoryRepository) GetCategoriesByName(name string) (categories []mode
 	return
 }
 
+func (r *CategoryRepository) GetNavCategories(universe string) (children []int64, err error) {
+	rows, err := r.DB.Query(`SELECT id FROM categories
+	                         WHERE SUBSTRING_INDEX(ancestry, '/', -1) = (
+	                         	SELECT id FROM categories WHERE universe = ? AND ancestry IS NULL
+	                         )
+	                         AND NOT hidden
+	                         ORDER BY list_order;`, universe)
+	if err != nil {
+		return
+	}
+	for rows.Next() {
+		var childId int64
+		err = rows.Scan(&childId)
+		if err != nil {
+			return
+		}
+		children = append(children, childId)
+	}
+	return
+}
+
 func (r *CategoryRepository) GetChildrenOf(id int64) (children []int64, err error) {
 	rows, err := r.DB.Query(`SELECT id FROM categories
 	                         WHERE SUBSTRING_INDEX(ancestry, '/', -1) = ?

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -419,14 +419,16 @@ func (r *CategoryRepository) CreateCategoryPackage(
 	var universe string
 	for _, kidId := range kids {
 		inflatedCat := models.CategoryWithInflatedSeries{}
-		category, err := r.GetCategoryById(kidId)
-		if err != nil {
+		category, an_err := r.GetCategoryById(kidId)
+		if an_err != nil {
+			err = an_err
 			return
 		}
 		inflatedCat.Category = category
 
-		seriesList, err := seriesRepository.GetInflatedSeriesByGroupGeoAndFreq(kidId, geoHandle, freq, Category)
-		if err != nil {
+		seriesList, an_err := seriesRepository.GetInflatedSeriesByGroupGeoAndFreq(kidId, geoHandle, freq, Category)
+		if an_err != nil {
+			err = an_err
 			return
 		}
 		inflatedCat.Series = seriesList

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -411,9 +411,9 @@ func (r *CategoryRepository) CreateCategoryPackage(
 	freq string,
 	seriesRepository *SeriesRepository,
 ) (pkg models.DataPortalCategoryPackage, err error) {
+
 	kids, err := r.GetChildrenOf(id)
 	if err != nil {
-
 		return
 	}
 	var universe string

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -292,24 +292,20 @@ func (r *CategoryRepository) GetCategoriesByName(name string) (categories []mode
 	return
 }
 
-func (r *CategoryRepository) GetChildrenOf(id int64) (categories []models.Category, err error) {
-	rows, err := r.DB.Query(`SELECT id, name, parent_id FROM categories
-							 WHERE parent_id = ? AND NOT hidden
-							 ORDER BY list_order;`, id)
+func (r *CategoryRepository) GetChildrenOf(id int64) (children []int64, err error) {
+	rows, err := r.DB.Query(`SELECT id FROM categories
+	                         WHERE SUBSTRING_INDEX(ancestry, '/', -1) = ?
+	                         AND NOT hidden ORDER BY list_order;`, id)
 	if err != nil {
 		return
 	}
 	for rows.Next() {
-		category := models.Category{}
-		err = rows.Scan(
-			&category.Id,
-			&category.Name,
-			&category.ParentId,
-		)
+		var child_id int64
+		err = rows.Scan(&child_id)
 		if err != nil {
 			return
 		}
-		categories = append(categories, category)
+		children = append(children, child_id)
 	}
 	return
 }

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -309,12 +309,12 @@ func (r *CategoryRepository) GetChildrenOf(id int64) (children []int64, err erro
 		return
 	}
 	for rows.Next() {
-		var child_id int64
-		err = rows.Scan(&child_id)
+		var childId int64
+		err = rows.Scan(&childId)
 		if err != nil {
 			return
 		}
-		children = append(children, child_id)
+		children = append(children, childId)
 	}
 	return
 }

--- a/models/models.go
+++ b/models/models.go
@@ -58,8 +58,8 @@ type CategoryWithAncestry struct {
 }
 
 type DataPortalCategoryPackage struct {
-	ChildCategories	[]CategoryWithInflatedSeries	`json:"children"`
-	AllCategories	[]Category			`json:"categories"`
+	Children	[]CategoryWithInflatedSeries	`json:"categories"`
+	NavCategories	[]Category			`json:"navCategories"`
 }
 
 type CategoryWithInflatedSeries struct {

--- a/models/models.go
+++ b/models/models.go
@@ -58,11 +58,11 @@ type CategoryWithAncestry struct {
 }
 
 type DataPortalCategoryPackage struct {
-	ChildCategories	[]InflatedCategoryAndSeries	`json:"children"`
+	ChildCategories	[]CategoryWithInflatedSeries	`json:"children"`
 	AllCategories	[]Category			`json:"categories"`
 }
 
-type InflatedCategoryAndSeries struct {
+type CategoryWithInflatedSeries struct {
 	Category
 	Series []InflatedSeries		`json:"series"`
 }

--- a/models/models.go
+++ b/models/models.go
@@ -55,6 +55,11 @@ type CategoryWithAncestry struct {
 	ObservationEnd  	NullTime
 }
 
+type DataPortalCategoryView struct {
+	Categories	[]Category		`json:"categories"`
+	// series needed
+}
+
 type SearchSummary struct {
 	SearchText           string                  `json:"q"`
 	DefaultGeo           *DataPortalGeography    `json:"defaultGeo,omitempty"`

--- a/models/models.go
+++ b/models/models.go
@@ -58,7 +58,7 @@ type CategoryWithAncestry struct {
 }
 
 type DataPortalCategoryPackage struct {
-	Children	[]CategoryWithInflatedSeries	`json:"categories"`
+	CatSubTree	[]CategoryWithInflatedSeries	`json:"categories"`
 	NavCategories	[]Category			`json:"navCategories"`
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -60,7 +60,6 @@ type CategoryWithAncestry struct {
 type DataPortalCategoryPackage struct {
 	ChildCategories	[]InflatedCategoryAndSeries	`json:"children"`
 	AllCategories	[]Category			`json:"categories"`
-	// series needed
 }
 
 type InflatedCategoryAndSeries struct {

--- a/models/models.go
+++ b/models/models.go
@@ -55,11 +55,15 @@ type CategoryWithAncestry struct {
 	ObservationEnd  	NullTime
 }
 
-type DataPortalCategoryView struct {
-	InflatedSeries	[]InflatedSeries	`json:"series"`
-	ChildCategories	[]Category		`json:"children"`
-	AllCategories	[]Category		`json:"categories"`
+type DataPortalCategoryPackage struct {
+	ChildCategories	[]InflatedCategorySeries	`json:"children"`
+	AllCategories	[]Category			`json:"categories"`
 	// series needed
+}
+
+type InflatedCategorySeries struct {
+	Category
+	Series []InflatedSeries		`json:"series"`
 }
 
 type SearchSummary struct {

--- a/models/models.go
+++ b/models/models.go
@@ -59,12 +59,12 @@ type CategoryWithAncestry struct {
 
 type DataPortalCategoryPackage struct {
 	CatSubTree	[]CategoryWithInflatedSeries	`json:"categories"`
-	NavCategories	[]Category			`json:"navCategories"`
+	NavCategories	[]Category			`json:"navCategories,omitempty"`
 }
 
 type CategoryWithInflatedSeries struct {
 	Category
-	Series []InflatedSeries		`json:"series"`
+	Series []InflatedSeries		`json:"series,omitempty"`
 }
 
 type SearchSummary struct {

--- a/models/models.go
+++ b/models/models.go
@@ -56,7 +56,9 @@ type CategoryWithAncestry struct {
 }
 
 type DataPortalCategoryView struct {
-	Categories	[]Category		`json:"categories"`
+	InflatedSeries	[]InflatedSeries	`json:"series"`
+	ChildCategories	[]Category		`json:"children"`
+	AllCategories	[]Category		`json:"categories"`
 	// series needed
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -56,12 +56,12 @@ type CategoryWithAncestry struct {
 }
 
 type DataPortalCategoryPackage struct {
-	ChildCategories	[]InflatedCategorySeries	`json:"children"`
+	ChildCategories	[]InflatedCategoryAndSeries	`json:"children"`
 	AllCategories	[]Category			`json:"categories"`
 	// series needed
 }
 
-type InflatedCategorySeries struct {
+type InflatedCategoryAndSeries struct {
 	Category
 	Series []InflatedSeries		`json:"series"`
 }

--- a/routers/category.go
+++ b/routers/category.go
@@ -103,10 +103,20 @@ func SetCategoryRoutes(
 	router.HandleFunc(
 		"/v1/category/series",
 		controllers.GetSeriesByGroupId(seriesRepository, cacheRepository, data.Category),
-	).Methods("GET").Queries("id", "{id:[0-9]+}")
+	).Methods("GET").Queries(
+		"id", "{id:[0-9]+}"
+	)
 	router.HandleFunc(
 		"/v1/category/measurements",
 		controllers.GetMeasurementByCategoryId(measurementRepository, cacheRepository),
-	).Methods("GET").Queries("id", "{id:[0-9]+}")
+	).Methods("GET").Queries(
+		"id", "{id:[0-9]+}"
+	)
+	router.HandleFunc(
+		"/v1/category/view",
+		controllers.GetCategoryView(categoryRepository, seriesRepository, cacheRepository),
+	).Methods("GET").Queries(
+		"id", "{id:[0-9]+}"
+	)
 	return router
 }

--- a/routers/category.go
+++ b/routers/category.go
@@ -38,7 +38,7 @@ func SetCategoryRoutes(
 		controllers.GetCategoriesByUniverse(categoryRepository, cacheRepository),
 	).Methods("GET").Queries(
 		"u", "{universe_text:.+}",
-		"type", "nav",
+		"type", "{type_text:.+}",
 	)
 	router.HandleFunc(
 		"/v1/category",

--- a/routers/category.go
+++ b/routers/category.go
@@ -116,7 +116,9 @@ func SetCategoryRoutes(
 		"/v1/category/view",
 		controllers.GetCategoryView(categoryRepository, seriesRepository, cacheRepository),
 	).Methods("GET").Queries(
-		"id", "{id:[0-9]+}"
+		"id", "{id:[0-9]+}",
+		"geo", "{geo:[A-Za-z0-9]+}",
+		"freq", "{freq:[ASQMWDasqmwd]}",
 	)
 	return router
 }

--- a/routers/category.go
+++ b/routers/category.go
@@ -38,6 +38,13 @@ func SetCategoryRoutes(
 		controllers.GetCategoriesByUniverse(categoryRepository, cacheRepository),
 	).Methods("GET").Queries(
 		"u", "{universe_text:.+}",
+		"type", "nav",
+	)
+	router.HandleFunc(
+		"/v1/category",
+		controllers.GetCategoriesByUniverse(categoryRepository, cacheRepository),
+	).Methods("GET").Queries(
+		"u", "{universe_text:.+}",
 	)
 	router.HandleFunc(
 		"/v1/category",

--- a/routers/category.go
+++ b/routers/category.go
@@ -104,13 +104,13 @@ func SetCategoryRoutes(
 		"/v1/category/series",
 		controllers.GetSeriesByGroupId(seriesRepository, cacheRepository, data.Category),
 	).Methods("GET").Queries(
-		"id", "{id:[0-9]+}"
+		"id", "{id:[0-9]+}",
 	)
 	router.HandleFunc(
 		"/v1/category/measurements",
 		controllers.GetMeasurementByCategoryId(measurementRepository, cacheRepository),
 	).Methods("GET").Queries(
-		"id", "{id:[0-9]+}"
+		"id", "{id:[0-9]+}",
 	)
 	return router
 }

--- a/routers/category.go
+++ b/routers/category.go
@@ -112,13 +112,5 @@ func SetCategoryRoutes(
 	).Methods("GET").Queries(
 		"id", "{id:[0-9]+}"
 	)
-	router.HandleFunc(
-		"/v1/category/view",
-		controllers.GetCategoryView(categoryRepository, seriesRepository, cacheRepository),
-	).Methods("GET").Queries(
-		"id", "{id:[0-9]+}",
-		"geo", "{geo:[A-Za-z0-9]+}",
-		"freq", "{freq:[ASQMWDasqmwd]}",
-	)
 	return router
 }

--- a/routers/package.go
+++ b/routers/package.go
@@ -26,5 +26,10 @@ func SetPackageRoutes(
 		"geo", "{geo:[A-Za-z0-9]+}",
 		"freq", "{freq:[ASQMWDasqmwd]}",
 	)
+	router.HandleFunc(
+		"/v1/package/category",
+		controllers.GetCategoryPackage(categoryRepository, seriesRepository, cacheRepository),
+	).Methods("GET")
+
 	return router
 }

--- a/routers/package.go
+++ b/routers/package.go
@@ -18,5 +18,11 @@ func SetPackageRoutes(
 	).Methods("GET").Queries(
 		"id", "{id:[0-9]+}",
 	)
+	router.HandleFunc(
+		"/v1/package/category",
+		controllers.GetCategoryPackage(categoryRepository, seriesRepository, cacheRepository),
+	).Methods("GET").Queries(
+		"id", "{id:[0-9]+}",
+	)
 	return router
 }

--- a/routers/package.go
+++ b/routers/package.go
@@ -29,7 +29,8 @@ func SetPackageRoutes(
 	router.HandleFunc(
 		"/v1/package/category",
 		controllers.GetCategoryPackage(categoryRepository, seriesRepository, cacheRepository),
-	).Methods("GET")
-
+	).Methods("GET").Queries(
+		"u", "{universe_text:.+}",
+	)
 	return router
 }

--- a/routers/package.go
+++ b/routers/package.go
@@ -23,6 +23,8 @@ func SetPackageRoutes(
 		controllers.GetCategoryPackage(categoryRepository, seriesRepository, cacheRepository),
 	).Methods("GET").Queries(
 		"id", "{id:[0-9]+}",
+		"geo", "{geo:[A-Za-z0-9]+}",
+		"freq", "{freq:[ASQMWDasqmwd]}",
 	)
 	return router
 }


### PR DESCRIPTION
New endpoint `/v1/package/category?id=&geo=&freq=` returns all the data needed for top-level category page on the data portals, including all child categories with their expanded series (`categories`), plus all navigational categories for the given category's universe (`navCategories`). The geo and freq parameters are the ones that would normally be passed to the `/v1/category/series` endpoint when retrieving appropriate inflated series.

New endpoint is not used in data portals yet, so can only be tested by direct API access (using Postman or whatever). Only works for navigational categories, that have children. Some examples are:

`/v1/package/category?id=21&geo=HON&freq=A`
`/v1/package/category?id=31&geo=HI&freq=Q`
`/v1/package/category?id=36&geo=HAW&freq=M`

Method `data.GetChildrenOf` has been restored, with a new and different implementation :)

Addendum:
Following additions/changes were made after discussions:
* Only navigational categories are returned as the second contained list, rather than all categories.
* New endpoint `/v1/package/category?u=`, which will return the equivalent of the above "canonical" endpoint, but with the implied `id` of the default navigational category of the supplied universe, and that category's default geo and freq.
* New endpoint  `/v1/category?u=&type=nav` (note, not a `/package`), will return only navigational categories, rather than all. They are returned in order as determined by `list_order` property. This was only exposed as an endpoint because its function had been implemented for other purposes, but perhaps it will prove useful.
* The parent nav category is added to the `categories` list, which had been only children.
* Labels of the contained objects returned are changed, and these are reflected in the edited description above.