### PR TITLE
New endpoint /v1/package/analyzer (UA-810)

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -126,8 +126,8 @@ func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
 	return
 }
 
-func getIdsList(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
-	getId(w, r) //placeholder for now
+func getIdsList(w http.ResponseWriter, r *http.Request) (ids []int64, ok bool) {
+	return
 }
 
 func getIdAndGeo(w http.ResponseWriter, r *http.Request) (id int64, geo string, ok bool) {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -126,6 +126,10 @@ func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
 	return
 }
 
+func getIdsList(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
+	getId(w, r) //placeholder for now
+}
+
 func getIdAndGeo(w http.ResponseWriter, r *http.Request) (id int64, geo string, ok bool) {
 	ok = true
 	idParam, gotId := mux.Vars(r)["id"]

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -128,13 +128,13 @@ func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
 }
 
 func getIdsList(w http.ResponseWriter, r *http.Request) (ids []int64, ok bool) {
-	idsParam, gotIds := mux.Vars(r)["ids"]
+	idsList, gotIds := mux.Vars(r)["ids_list"]
 	if !gotIds {
 		common.DisplayAppError(w, errors.New("Couldn't get id from request"),"Bad request.", 400)
 		ok = false
 		return
 	}
-	idStrArr := strings.Split(idsParam, ",")
+	idStrArr := strings.Split(idsList, ",")
 	for _, idStr := range idStrArr {
 		id, err := strconv.ParseInt(idStr, 10, 64)
 		if err != nil {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 func CheckCache(c *data.CacheRepository) func(http.ResponseWriter, *http.Request, http.HandlerFunc) {
@@ -127,6 +128,22 @@ func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
 }
 
 func getIdsList(w http.ResponseWriter, r *http.Request) (ids []int64, ok bool) {
+	idsParam, gotIds := mux.Vars(r)["ids"]
+	if !gotIds {
+		common.DisplayAppError(w, errors.New("Couldn't get id from request"),"Bad request.", 400)
+		ok = false
+		return
+	}
+	idStrArr := strings.Split(idsParam, ",")
+	for _, idStr := range idStrArr {
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			common.DisplayAppError(w, err,"An unexpected error has occurred",500)
+			ok = false
+			return
+		}
+		ids = append(ids, id)
+	}
 	return
 }
 

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -128,6 +128,7 @@ func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
 }
 
 func getIdsList(w http.ResponseWriter, r *http.Request) (ids []int64, ok bool) {
+	ok = true
 	idsList, gotIds := mux.Vars(r)["ids_list"]
 	if !gotIds {
 		common.DisplayAppError(w, errors.New("Couldn't get id from request"),"Bad request.", 400)

--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -92,4 +92,9 @@ type (
 	SearchPackage struct {
 		Data models.DataPortalSearchPackage `json:"data"`
 	}
+
+	// GET - /package/analyzer
+	AnalyzerPackage struct {
+		Data models.DataPortalAnalyzerPackage `json:"data"`
+	}
 )

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -325,27 +325,15 @@ func GetAnalyzerPackage(
 	return func(w http.ResponseWriter, r *http.Request) {
 		universe, ok := mux.Vars(r)["universe_text"]
 		if !ok {
-			common.DisplayAppError(
-				w,
-				errors.New("Couldn't get universe handle from request"),
-				"Bad request.",
-				400,
-			)
-			ok = false
+			common.DisplayAppError(w, errors.New("Couldn't get universe handle from request"),"Bad request.",400)
 			return
 		}
 		ids, ok := getIdsList(w, r)
 		if !ok {
-			common.DisplayAppError(
-				w,
-				errors.New("Couldn't get id list from request"),
-				"Bad request.",
-				400,
-			)
-			ok = false
+			common.DisplayAppError(w, errors.New("Couldn't get id list from request"),"Bad request.",400)
 			return
 		}
-		pkg, err := categoryRepository.CreateAnalyzerPackage(universe, ids, seriesRepository)
+		pkg, err := seriesRepository.CreateAnalyzerPackage(universe, ids, categoryRepository)
 		if err != nil {
 			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -330,7 +330,6 @@ func GetAnalyzerPackage(
 		}
 		ids, ok := getIdsList(w, r)
 		if !ok {
-			common.DisplayAppError(w, errors.New("Couldn't get id list from request"),"Bad request.",400)
 			return
 		}
 		pkg, err := seriesRepository.CreateAnalyzerPackage(universe, ids, categoryRepository)

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -6,8 +6,6 @@ import (
 	"github.com/UHERO/rest-api/common"
 	"github.com/UHERO/rest-api/data"
 	"github.com/UHERO/rest-api/models"
-	"github.com/gorilla/mux"
-	"errors"
 )
 
 func GetSeriesByGroupId(
@@ -323,16 +321,12 @@ func GetAnalyzerPackage(
 	cacheRepository *data.CacheRepository,
 ) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		universe, ok := mux.Vars(r)["universe_text"]
-		if !ok {
-			common.DisplayAppError(w, errors.New("Couldn't get universe handle from request"),"Bad request.",400)
-			return
-		}
+
 		ids, ok := getIdsList(w, r)
 		if !ok {
 			return
 		}
-		pkg, err := seriesRepository.CreateAnalyzerPackage(universe, ids, categoryRepository)
+		pkg, err := seriesRepository.CreateAnalyzerPackage(ids, categoryRepository)
 		if err != nil {
 			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -314,3 +314,21 @@ func GetSeriesPackage(
 		WriteCache(r, cacheRepository, j)
 	}
 }
+
+func GetAnalyzerPackage(
+	categoryRepository *data.CategoryRepository,
+	seriesRepository *data.SeriesRepository,
+	cacheRepository *data.CacheRepository,
+) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		pkg := models.DataPortalAnalyzerPackage{}
+
+		j, err := json.Marshal(AnalyzerPackage{Data: pkg})
+		if err != nil {
+			common.DisplayAppError(w, err, "An unexpected error processing JSON has occurred", 500)
+			return
+		}
+		WriteResponse(w, j)
+		WriteCache(r, cacheRepository, j)
+	}
+}

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/UHERO/rest-api/models"
 	"strconv"
+	"github.com/UHERO/rest-api/common"
 )
 
 type SeriesRepository struct {
@@ -777,4 +778,25 @@ func (r *SeriesRepository) GetTransformation(
 	transformationResult.ObservationValues = obsValues
 	transformationResult.ObservationPHist = obsPseudoHist
 	return
+}
+
+func (r *SeriesRepository) CreateAnalyzerPackage(
+	universe string,
+	ids []int64,
+	categoryRepository *CategoryRepository,
+)  (pkg models.DataPortalAnalyzerPackage, err error) {
+	categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
+	if err != nil {
+		return
+	}
+	pkg.Categories = categories
+
+	for _, id := range ids {
+		series, err := r.GetSeriesById(id)
+		if err != nil {
+			return
+		}
+		pkg.Series = append(pkg.Series, series)
+	}
+
 }

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -783,6 +783,7 @@ func (r *SeriesRepository) CreateAnalyzerPackage(
 	ids []int64,
 	categoryRepository *CategoryRepository,
 )  (pkg models.DataPortalAnalyzerPackage, err error) {
+
 	categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
 	if err != nil {
 		return

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -1,13 +1,11 @@
 package data
 
 import (
+	"github.com/UHERO/rest-api/models"
 	"database/sql"
 	"strings"
 	"time"
-
-	"github.com/UHERO/rest-api/models"
 	"strconv"
-	"github.com/UHERO/rest-api/common"
 )
 
 type SeriesRepository struct {
@@ -790,13 +788,20 @@ func (r *SeriesRepository) CreateAnalyzerPackage(
 		return
 	}
 	pkg.Categories = categories
+	pkg.InflatedSeries = []models.InflatedSeries{}
 
 	for _, id := range ids {
-		series, err := r.GetSeriesById(id)
-		if err != nil {
+		series, anErr := r.GetSeriesById(id)
+		if anErr != nil {
+			err = anErr
 			return
 		}
-		pkg.Series = append(pkg.Series, series)
+		observations, anErr := r.GetSeriesObservations(id)
+		if anErr != nil {
+			err = anErr
+			return
+		}
+		pkg.InflatedSeries = append(pkg.InflatedSeries, models.InflatedSeries{DataPortalSeries: series, Observations: observations})
 	}
-
+	return
 }

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -779,16 +779,11 @@ func (r *SeriesRepository) GetTransformation(
 }
 
 func (r *SeriesRepository) CreateAnalyzerPackage(
-	universe string,
 	ids []int64,
 	categoryRepository *CategoryRepository,
 )  (pkg models.DataPortalAnalyzerPackage, err error) {
 
-	categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
-	if err != nil {
-		return
-	}
-	pkg.Categories = categories
+	var universe string
 	pkg.InflatedSeries = []models.InflatedSeries{}
 
 	for _, id := range ids {
@@ -797,6 +792,8 @@ func (r *SeriesRepository) CreateAnalyzerPackage(
 			err = anErr
 			return
 		}
+		universe = series.Universe
+
 		observations, anErr := r.GetSeriesObservations(id)
 		if anErr != nil {
 			err = anErr
@@ -804,5 +801,11 @@ func (r *SeriesRepository) CreateAnalyzerPackage(
 		}
 		pkg.InflatedSeries = append(pkg.InflatedSeries, models.InflatedSeries{DataPortalSeries: series, Observations: observations})
 	}
+
+	categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
+	if err != nil {
+		return
+	}
+	pkg.Categories = categories
 	return
 }

--- a/models/models.go
+++ b/models/models.go
@@ -83,6 +83,8 @@ type DataPortalSearchPackage struct {
 }
 
 type DataPortalAnalyzerPackage struct {
+	Categories	[]Category			`json:"categories,omitempty"`
+	Series		[]DataPortalSeries	`json:"series,omitempty"`
 }
 
 type Geography struct {

--- a/models/models.go
+++ b/models/models.go
@@ -83,8 +83,8 @@ type DataPortalSearchPackage struct {
 }
 
 type DataPortalAnalyzerPackage struct {
-	Categories	[]Category			`json:"categories,omitempty"`
-	Series		[]DataPortalSeries	`json:"series,omitempty"`
+	Categories		[]Category				`json:"categories,omitempty"`
+	InflatedSeries	[]InflatedSeries		`json:"series,omitempty"`
 }
 
 type Geography struct {

--- a/models/models.go
+++ b/models/models.go
@@ -82,6 +82,9 @@ type DataPortalSearchPackage struct {
 	Series []InflatedSeries		`json:"series,omitempty"`
 }
 
+type DataPortalAnalyzerPackage struct {
+}
+
 type Geography struct {
 	FIPS             sql.NullString `json:"fips"`
 	Name             sql.NullString `json:"name"`

--- a/routers/package.go
+++ b/routers/package.go
@@ -54,6 +54,7 @@ func SetPackageRoutes(
 		controllers.GetAnalyzerPackage(categoryRepository, seriesRepository, cacheRepository),
 	).Methods("GET").Queries(
 		"u", "{universe_text:.+}",
+		    "ids", "{ids_list:[0-9,]+}",
 	)
 	return router
 }

--- a/routers/package.go
+++ b/routers/package.go
@@ -53,8 +53,7 @@ func SetPackageRoutes(
 		"/v1/package/analyzer",
 		controllers.GetAnalyzerPackage(categoryRepository, seriesRepository, cacheRepository),
 	).Methods("GET").Queries(
-		"u", "{universe_text:.+}",
-		    "ids", "{ids_list:[0-9,]+}",
+		"ids", "{ids_list:[0-9,]+}",
 	)
 	return router
 }

--- a/routers/package.go
+++ b/routers/package.go
@@ -49,5 +49,11 @@ func SetPackageRoutes(
 	).Methods("GET").Queries(
 		"u", "{universe_text:.+}",
 	)
+	router.HandleFunc(
+		"/v1/package/analyzer",
+		controllers.GetAnalyzerPackage(categoryRepository, seriesRepository, cacheRepository),
+	).Methods("GET").Queries(
+		"u", "{universe_text:.+}",
+	)
 	return router
 }


### PR DESCRIPTION
New endpoint `/v1/package/analyzer?ids=xxx[,yyy[,zzz...]]` where the `xxx` etc are any number of series IDs, comma-separated. Each series is returned in its inflated form (with data points), and also all the categories for the universe that the series belong to (seems like a safe bet that requests for multiple series will always be for ones inhabiting the same universe).