### PR TITLE
/package/category endpoint handles more than two levels (UA-882)

### DIFF
--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -511,16 +511,19 @@ func (r *CategoryRepository) getCategoryTree(
 		return
 	}
 	for _, kid := range kids {
-		inflatedCat := models.CategoryWithInflatedSeries{}
-//		var moreKids []models.CategoryWithInflatedSeries{}
-
 		if kid.IsHeader {
-			inflatedCat.Category = kid
+			stuff = append(stuff, models.CategoryWithInflatedSeries{Category: kid})
+
 			moreKids, anErr := r.getCategoryTree(kid.Id, geo, freq, seriesRepository)
 			if anErr != nil {
 				return
 			}
+			for _, k := range moreKids {
+				stuff = append(stuff, k)
+			}
 		} else {
+			inflatedCat := models.CategoryWithInflatedSeries{}
+
 			category, anErr := r.GetCategoryById(kid.Id)
 			if anErr != nil {
 				err = anErr
@@ -536,10 +539,7 @@ func (r *CategoryRepository) getCategoryTree(
 				}
 				inflatedCat.Series = seriesList
 			}
-		}
-		pkg.CatSubTree = append(pkg.CatSubTree, inflatedCat)
-		for _, subKid := range moreKids {
-			pkg.CatSubTree = append(pkg.CatSubTree, subKid)
+			stuff = append(stuff, inflatedCat)
 		}
 	}
 	return

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -525,26 +525,26 @@ func (r *CategoryRepository) getCategoryTree(
 			for _, cat := range subtree {
 				tree = append(tree, cat)
 			}
-		} else {
-			inflatedCat := models.CategoryWithInflatedSeries{}
+			continue
+		}
+		inflatedCat := models.CategoryWithInflatedSeries{}
 
-			category, anErr := r.GetCategoryById(kid.Id)
+		category, anErr := r.GetCategoryById(kid.Id)
+		if anErr != nil {
+			err = anErr
+			return
+		}
+		inflatedCat.Category = category
+
+		if geo != "" && freq != "" {
+			seriesList, anErr := seriesRepository.GetInflatedSeriesByGroupGeoAndFreq(kid.Id, geo, freq, Category)
 			if anErr != nil {
 				err = anErr
 				return
 			}
-			inflatedCat.Category = category
-
-			if geo != "" && freq != "" {
-				seriesList, anErr := seriesRepository.GetInflatedSeriesByGroupGeoAndFreq(kid.Id, geo, freq, Category)
-				if anErr != nil {
-					err = anErr
-					return
-				}
-				inflatedCat.Series = seriesList
-			}
-			tree = append(tree, inflatedCat)
+			inflatedCat.Series = seriesList
 		}
+		tree = append(tree, inflatedCat)
 	}
 	return
 }

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -445,7 +445,7 @@ func (r *CategoryRepository) GetCategoriesByName(name string) (categories []mode
 }
 
 func (r *CategoryRepository) GetChildrenOf(id int64) (children []models.Category, err error) {
-		rows, err := r.DB.Query(`SELECT categories.id, categories.universe, categories.name, data_list_id, header,
+		rows, err := r.DB.Query(`SELECT categories.id, categories.universe, categories.name, header,
 												geographies.handle, geographies.fips, geographies.display_name, geographies.display_name_short, default_freq
 										FROM categories LEFT JOIN geographies ON geographies.id = categories.default_geo_id
 										WHERE SUBSTRING_INDEX(categories.ancestry, '/', -1) = ?
@@ -461,8 +461,7 @@ func (r *CategoryRepository) GetChildrenOf(id int64) (children []models.Category
 			&dataPortalCategory.Id,
 			&dataPortalCategory.Name,
 			&dataPortalCategory.Universe,
-			&category.DataListId,
-			&category.IsHeader,
+			&dataPortalCategory.IsHeader,
 			&category.DefaultGeoHandle,
 			&category.DefaultGeoFIPS,
 			&category.DefaultGeoName,
@@ -517,23 +516,23 @@ func (r *CategoryRepository) CreateCategoryPackage(
 		inflatedCat := models.CategoryWithInflatedSeries{}
 		if kid.IsHeader {
 			inflatedCat.Category = kid
+
 		} else {
-
-		}
-		category, anErr := r.GetCategoryById(kid.Id)
-		if anErr != nil {
-			err = anErr
-			return
-		}
-		inflatedCat.Category = category
-
-		if geo != "" && freq != "" {
-			seriesList, anErr := seriesRepository.GetInflatedSeriesByGroupGeoAndFreq(kid.Id, geo, freq, Category)
+			category, anErr := r.GetCategoryById(kid.Id)
 			if anErr != nil {
 				err = anErr
 				return
 			}
-			inflatedCat.Series = seriesList
+			inflatedCat.Category = category
+
+			if geo != "" && freq != "" {
+				seriesList, anErr := seriesRepository.GetInflatedSeriesByGroupGeoAndFreq(kid.Id, geo, freq, Category)
+				if anErr != nil {
+					err = anErr
+					return
+				}
+				inflatedCat.Series = seriesList
+			}
 		}
 		pkg.CatSubTree = append(pkg.CatSubTree, inflatedCat)
 		universe = category.Universe

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -556,7 +556,9 @@ func (r *CategoryRepository) CreateCategoryPackage(
 	if err != nil {
 		return
 	}
-	copy(pkg.CatSubTree, theStuff)
+	for _, k := range theStuff {
+		pkg.CatSubTree = append(pkg.CatSubTree, k)
+	}
 	if len(theStuff) > 0 {
 		navCats, anErr := r.GetNavCategoriesByUniverse(theStuff[0].Category.Universe)
 		if anErr != nil {

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -473,8 +473,7 @@ func (r *CategoryRepository) GetChildrenOf(id int64) (children []models.Category
 			return
 		}
 		if category.Ancestry.Valid {
-			parentId := getParentId(category.Ancestry)
-			dataPortalCategory.ParentId = parentId
+			dataPortalCategory.ParentId = getParentId(category.Ancestry)
 		}
 		if category.DefaultFrequency.Valid || category.DefaultGeoHandle.Valid || category.ObservationStart.Valid || category.ObservationEnd.Valid {
 			// Only initialize Defaults struct if any defaults values are available

--- a/models/models.go
+++ b/models/models.go
@@ -50,6 +50,7 @@ type CategoryWithAncestry struct {
 	Ancestry		sql.NullString
 	ParentId		sql.NullInt64
 	IsHeader		bool
+	DataListId		sql.NullInt64
 	DefaultGeoHandle	sql.NullString
 	DefaultGeoFIPS		sql.NullString
 	DefaultGeoName		sql.NullString

--- a/models/models.go
+++ b/models/models.go
@@ -60,8 +60,8 @@ type CategoryWithAncestry struct {
 }
 
 type DataPortalCategoryPackage struct {
-	CatSubTree	[]CategoryWithInflatedSeries	`json:"categories"`
-	NavCategories	[]Category			`json:"navCategories,omitempty"`
+	CatSubTree		[]CategoryWithInflatedSeries	`json:"categories"`
+	NavCategories	[]Category						`json:"navCategories,omitempty"`
 }
 
 type CategoryWithInflatedSeries struct {

--- a/models/models.go
+++ b/models/models.go
@@ -50,7 +50,6 @@ type CategoryWithAncestry struct {
 	Ancestry		sql.NullString
 	ParentId		sql.NullInt64
 	IsHeader		bool
-	DataListId		sql.NullInt64
 	DefaultGeoHandle	sql.NullString
 	DefaultGeoFIPS		sql.NullString
 	DefaultGeoName		sql.NullString

--- a/tests/Full_suite.postman_collection.json
+++ b/tests/Full_suite.postman_collection.json
@@ -1053,7 +1053,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "2f143695-f6f9-45ac-943c-634168756a1f",
+						"id": "22badbc9-fa62-4a07-998e-0925e0acb0af",
 						"type": "text/javascript",
 						"exec": [
 							"var data = JSON.parse(responseBody).data;",
@@ -1061,7 +1061,10 @@
 							"tests[\"Response contains data\"] = typeof(data) === 'object';",
 							"tests[\"Response categories is non-empty array\"] = Array.isArray(data.categories) && data.categories.length > 0;",
 							"tests[\"Response navCategories is non-empty array\"] = Array.isArray(data.navCategories) && data.navCategories.length > 0;",
-							"tests[\"Response categories contains an element with name \"] = data.categories[0].name !== undefined;"
+							"tests[\"Response categories contains an element with name \"] = data.categories[0].name !== undefined;",
+							"var lastcat = data.categories[data.categories.length-1];",
+							"tests[\"Response categories final entry (parent) has no geos\"] = lastcat.geos === undefined;",
+							"tests[\"Response categories final entry (parent) is not header\"] = lastcat.isHeader === undefined;"
 						]
 					}
 				}
@@ -1117,7 +1120,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "2f143695-f6f9-45ac-943c-634168756a1f",
+						"id": "f01ef2b3-dce0-42fb-b239-e636830d37a8",
 						"type": "text/javascript",
 						"exec": [
 							"var data = JSON.parse(responseBody).data;",
@@ -1125,7 +1128,10 @@
 							"tests[\"Response contains data\"] = typeof(data) === 'object';",
 							"tests[\"Response categories is non-empty array\"] = Array.isArray(data.categories) && data.categories.length > 0;",
 							"tests[\"Response navCategories is non-empty array\"] = Array.isArray(data.navCategories) && data.navCategories.length > 0;",
-							"tests[\"Response categories contains an element with name \"] = data.categories[0].name !== undefined;"
+							"tests[\"Response categories contains an element with name \"] = data.categories[0].name !== undefined;",
+							"var lastcat = data.categories[data.categories.length-1];",
+							"tests[\"Response categories final entry (parent) has no geos\"] = lastcat.geos === undefined;",
+							"tests[\"Response categories final entry (parent) is not header\"] = lastcat.isHeader === undefined;"
 						]
 					}
 				}


### PR DESCRIPTION
Changes to allow this endpoint to traverse a category tree of arbitrary depth, with header nodes internally. Output of category objects is in depth-first order.

Note that data list leaf nodes can inherit a default geo/freq from the immediate parent if they don't have their own (this is an already existing feature), but this is not recursive up the tree, and undesirable behavior results if these defaults are not specified.