### PR TITLE
Changes for series to belong to multiple universes (UA-887-1)

### DIFF
--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -6,6 +6,7 @@ import (
 	"github.com/UHERO/rest-api/common"
 	"github.com/UHERO/rest-api/data"
 	"github.com/UHERO/rest-api/models"
+	"github.com/gorilla/mux"
 )
 
 func GetSeriesByGroupId(
@@ -326,7 +327,11 @@ func GetAnalyzerPackage(
 		if !ok {
 			return
 		}
-		pkg, err := seriesRepository.CreateAnalyzerPackage(ids, categoryRepository)
+		universe, ok := mux.Vars(r)["universe_text"]
+		if !ok {
+			return
+		}
+		pkg, err := seriesRepository.CreateAnalyzerPackage(ids, universe, categoryRepository)
 		if err != nil {
 			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return

--- a/data/search.go
+++ b/data/search.go
@@ -39,7 +39,7 @@ func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, u
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
-	WHERE series.universe = UPPER(?)
+	WHERE series.universe LIKE CONCAT('%',?,'%')
 	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	AND ((MATCH(series.name, series.description, series.dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
@@ -86,14 +86,14 @@ func (r *SearchRepository) GetSearchSummaryByUniverse(searchText string, univers
 	      SELECT series_id FROM measurement_series WHERE measurement_id IN (
 		SELECT measurement_id FROM data_list_measurements WHERE data_list_id IN (
 		  SELECT data_list_id FROM categories
-		  WHERE universe = UPPER(?)
+		  WHERE universe LIKE CONCAT('%',?,'%')
 		  AND ((MATCH(name) AGAINST(? IN NATURAL LANGUAGE MODE))
 		    OR (LOWER(COALESCE(name, '')) LIKE CONCAT('%', LOWER(?), '%')))
 		)
 	      )
 	      UNION
 	      SELECT id AS series_id FROM series
-	      WHERE universe = UPPER(?)
+	      WHERE universe LIKE CONCAT('%',?,'%')
 	      AND ((MATCH(name, description, dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	        OR LOWER(CONCAT(name, COALESCE(description, ''), COALESCE(dataPortalName, ''))) LIKE CONCAT('%', LOWER(?), '%'))
 	    ) AS s ON s.series_id = series.id
@@ -131,7 +131,7 @@ func (r *SearchRepository) GetSearchSummaryByUniverse(searchText string, univers
 	LEFT JOIN data_list_measurements ON data_list_measurements.measurement_id = measurement_series.measurement_id
 	LEFT JOIN categories ON categories.data_list_id = data_list_measurements.data_list_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
-	WHERE series.universe = UPPER(?)
+	WHERE series.universe LIKE CONCAT('%',?,'%')
 	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT quarantined)
 	AND ((MATCH(series.name, series.description, dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
@@ -239,7 +239,7 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreqAndUniverse(
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
-	WHERE series.universe = UPPER(?)
+	WHERE series.universe LIKE concat('%',?,'%')
 	AND geo.handle = ?
 	AND series.frequency = ?
 	AND NOT series.restricted
@@ -315,7 +315,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
-	WHERE series.universe = UPPER(?)
+	WHERE series.universe LIKE CONCAT('%',?,'%')
 	AND geo.handle = ?
 	AND series.frequency = ?
 	AND NOT series.restricted

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -180,8 +180,7 @@ var measurementSeriesPrefix = `SELECT
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
-	WHERE measurements.id = ?
-	AND NOT series.restricted
+	WHERE measurements.id = ? AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
 var geoFilter = ` AND geographies.handle = UPPER(?) `
 var freqFilter = ` AND series.frequency = ? `

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -778,6 +778,38 @@ func (r *SeriesRepository) GetTransformation(
 	return
 }
 
+func (r *SeriesRepository) CreateSeriesPackage(
+	id int64,
+	universe string,
+	categoryRepository *CategoryRepository,
+)  (pkg models.DataPortalSeriesPackage, err error) {
+
+	series, err := r.GetSeriesById(id)
+	if err != nil {
+		return
+	}
+	pkg.Series = series
+
+	categories, err := categoryRepository.GetAllCategoriesByUniverse(universe)
+	if err != nil {
+		return
+	}
+	pkg.Categories = categories
+
+	observations, err := r.GetSeriesObservations(id)
+	if err != nil {
+		return
+	}
+	pkg.Observations = observations
+
+	siblings, err := r.GetSeriesSiblingsById(id)
+	if err != nil {
+		return
+	}
+	pkg.Siblings = siblings
+	return
+}
+
 func (r *SeriesRepository) CreateAnalyzerPackage(
 	ids []int64,
 	universe string,

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -179,8 +179,9 @@ var measurementSeriesPrefix = `SELECT
 	LEFT JOIN sources AS measurement_sources ON measurement_sources.id = measurements.source_id
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
-	LEFT JOIN feature_toggles ON feature_toggles.universe = measurements.universe AND feature_toggles.name = 'filter_by_quarantine'
-	WHERE measurements.id = ? AND NOT series.restricted
+	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
+	WHERE measurements.id = ?
+	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
 var geoFilter = ` AND geographies.handle = UPPER(?) `
 var freqFilter = ` AND series.frequency = ? `

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -780,10 +780,10 @@ func (r *SeriesRepository) GetTransformation(
 
 func (r *SeriesRepository) CreateAnalyzerPackage(
 	ids []int64,
+	universe string,
 	categoryRepository *CategoryRepository,
 )  (pkg models.DataPortalAnalyzerPackage, err error) {
 
-	var universe string
 	pkg.InflatedSeries = []models.InflatedSeries{}
 
 	for _, id := range ids {
@@ -792,8 +792,6 @@ func (r *SeriesRepository) CreateAnalyzerPackage(
 			err = anErr
 			return
 		}
-		universe = series.Universe
-
 		observations, anErr := r.GetSeriesObservations(id)
 		if anErr != nil {
 			err = anErr

--- a/routers/package.go
+++ b/routers/package.go
@@ -54,6 +54,7 @@ func SetPackageRoutes(
 		controllers.GetAnalyzerPackage(categoryRepository, seriesRepository, cacheRepository),
 	).Methods("GET").Queries(
 		"ids", "{ids_list:[0-9,]+}",
+		"u", "{universe_text:.+}",
 	)
 	return router
 }

--- a/routers/package.go
+++ b/routers/package.go
@@ -18,6 +18,7 @@ func SetPackageRoutes(
 		controllers.GetSeriesPackage(seriesRepository, categoryRepository, cacheRepository),
 	).Methods("GET").Queries(
 		"id", "{id:[0-9]+}",
+		"u", "{universe_text:.+}",
 	)
 	router.HandleFunc(
 		"/v1/package/search",

--- a/tests/Full_suite.postman_collection.json
+++ b/tests/Full_suite.postman_collection.json
@@ -866,14 +866,14 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "0240baa3-284e-4ddb-8b4c-653daeb7ef52",
+						"id": "82ae0a1a-8baf-4ccd-a8ea-0241d216e10b",
 						"type": "text/javascript",
 						"exec": [
 							"var data = JSON.parse(responseBody).data;",
 							"tests[\"Status code is 200\"] = responseCode.code === 200;",
 							"tests[\"Response contains data\"] = typeof(data) === 'object';",
-							"tests[\"Response has categories and series\"] = Array.isArray(data.categories) && Array.isArray(data.series);",
-							"tests[\"Response categories is array\"] = Array.isArray(data.categories);",
+							"tests[\"Response series is non-empty array\"] = Array.isArray(data.series) && data.series.length > 0;",
+							"tests[\"Response categories is non-empty array\"] = Array.isArray(data.categories) && data.categories.length > 0;",
 							"tests[\"Response series contains an element with name\"] = data.series[0].name !== undefined;",
 							""
 						]
@@ -895,7 +895,7 @@
 				"header": [],
 				"body": {},
 				"url": {
-					"raw": "{{url}}/package/analyzer?ids=152239,152240",
+					"raw": "{{url}}/package/analyzer?u=uhero&ids=152239,152240",
 					"host": [
 						"{{url}}"
 					],
@@ -904,6 +904,11 @@
 						"analyzer"
 					],
 					"query": [
+						{
+							"key": "u",
+							"value": "uhero",
+							"equals": true
+						},
 						{
 							"key": "ids",
 							"value": "152239,152240",
@@ -1177,7 +1182,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "0dbfcea9-c357-4670-a206-e5576c5853e4",
+						"id": "95517110-0f7a-4af9-83f6-e33b123d27b3",
 						"type": "text/javascript",
 						"exec": [
 							"var data = JSON.parse(responseBody).data;",
@@ -1185,7 +1190,9 @@
 							"tests[\"Response contains data\"] = typeof(data) === 'object';",
 							"tests[\"Response contains a series object\"] = data.series !== undefined;",
 							"tests[\"Response categories is non-empty array\"] = Array.isArray(data.categories) && data.categories.length > 0;",
-							"tests[\"Response categories contains an element with name \"] = data.categories[0].name !== undefined;"
+							"tests[\"Response categories contains an element with name \"] = data.categories[0].name !== undefined;",
+							"tests[\"Response contains an observations object\"] = data.observations !== undefined;",
+							"tests[\"Response siblings is non-empty array\"] = Array.isArray(data.siblings) && data.siblings.length > 0;"
 						]
 					}
 				}
@@ -1205,7 +1212,7 @@
 				"header": [],
 				"body": {},
 				"url": {
-					"raw": "{{url}}/package/series?id=148863",
+					"raw": "{{url}}/package/series?u=uhero&id=148863",
 					"host": [
 						"{{url}}"
 					],
@@ -1214,6 +1221,11 @@
 						"series"
 					],
 					"query": [
+						{
+							"key": "u",
+							"value": "uhero",
+							"equals": true
+						},
 						{
 							"key": "id",
 							"value": "148863",


### PR DESCRIPTION
`u=` universe parameter now required by `/v1/package/series` and `/v1/package/analyzer`.

Searching on universe accomplished with wildcard `LIKE` syntax in SQL.

Refactored series package creation to move logic appropriate to data gathering out of controller into model, on analogy to all the other package endpoints.