### PR TITLE
return data from GetCategoryByIdGeoFreq

### DIFF
--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -3,11 +3,12 @@ package data
 import (
 	"database/sql"
 	"errors"
-	"github.com/UHERO/rest-api/models"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/UHERO/rest-api/models"
 )
 
 type CategoryRepository struct {
@@ -529,7 +530,7 @@ func (r *CategoryRepository) getCategoryTree(
 		}
 		inflatedCat := models.CategoryWithInflatedSeries{}
 
-		category, anErr := r.GetCategoryById(kid.Id)
+		category, anErr := r.GetCategoryByIdGeoFreq(kid.Id, geo, freq)
 		if anErr != nil {
 			err = anErr
 			return

--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -3,12 +3,11 @@ package data
 import (
 	"database/sql"
 	"errors"
+	"github.com/UHERO/rest-api/models"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/UHERO/rest-api/models"
 )
 
 type CategoryRepository struct {


### PR DESCRIPTION
Not sure if this is the only change needed.

In the package/category endpoint, the API returns a current object that isn't updating the geo/freq based on the parameters it's given. It's returning HI.A regardless of the geo/freq requested.

For example, the /category?id=43&geo=HI&freq=A endpoint returns:
```
"current": {
    "geo": "HI",
    "freq": "A",
    "observationStart": "1950-01-01T00:00:00-10:00",
    "observationEnd": "2017-01-01T00:00:00-10:00"
}
```
and for /category?id=43&geo=MAUI&freq=A:
```
"current": {
    "geo": "MAUI",
    "freq": "A",
    "observationStart": "1991-01-01T00:00:00-10:00",
    "observationEnd": "2017-01-01T00:00:00-10:00"
},
```

But for /package/category?id=42&geo=MAUI&freq=A:
```
"current": {
    "geo": "HI",
    "freq": "A",
    "observationStart": "1950-01-01T00:00:00-10:00",
    "observationEnd": "2017-01-01T00:00:00-10:00"
},
```

(Also VSCode wants to rearrange the imports)