### PR TITLE
Do not return data when categories are masked (UA-911)

### DIFF
--- a/data/geoRepository.go
+++ b/data/geoRepository.go
@@ -51,7 +51,7 @@ func (r *GeographyRepository) GetGeographiesByCategory(categoryId int64) (geogra
 		LEFT JOIN geographies ON geographies.id = series.geography_id
 		LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 		WHERE (categories.id = ? OR categories.ancestry REGEXP CONCAT('[[:<:]]', ?, '[[:>:]]'))
-		AND NOT categories.hidden
+		AND NOT (categories.hidden OR categories.masked)
 		AND NOT series.restricted
 		AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined);`,
 		categoryId,

--- a/data/measurement.go
+++ b/data/measurement.go
@@ -19,7 +19,7 @@ func (r *MeasurementRepository) GetMeasurementsByCategory(categoryId int64) (
 		LEFT JOIN data_list_measurements ON categories.data_list_id = data_list_measurements.data_list_id
 		LEFT JOIN measurements ON data_list_measurements.measurement_id = measurements.id
 		WHERE categories.id = ?
-		AND NOT categories.hidden
+		AND NOT (categories.hidden OR categories.masked)
 		AND measurements.id IS NOT NULL
 		ORDER BY data_list_measurements.list_order;`,
 		categoryId,

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -156,7 +156,7 @@ var seriesPrefix = `SELECT
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE categories.id = ?
-	AND NOT categories.hidden
+	AND NOT (categories.hidden OR categories.masked)
 	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
 var measurementSeriesPrefix = `SELECT
@@ -446,7 +446,7 @@ func (r *SeriesRepository) GetFreqByCategory(categoryId int64) (frequencies []mo
 	LEFT JOIN series ON series.id = measurement_series.series_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE categories.id = ?
-	AND NOT categories.hidden
+	AND NOT (categories.hidden OR categories.masked)
 	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	ORDER BY FIELD(freq, "A", "S", "Q", "M", "W", "D");`, categoryId)


### PR DESCRIPTION
In addition to when they are `hidden`. Straightforward changes. But note I have also removed the `not hidden` test (for the sake of simplification) from queries to return data portal root categories, as we will no longer allow these to be hidden.