### PR TITLE
Categories limitable to specific geos and freqs (UA-915)

### DIFF
--- a/data/categoryRepository.go
+++ b/data/categoryRepository.go
@@ -311,9 +311,18 @@ func (r *CategoryRepository) GetCategoryByIdGeoFreq(id int64, originGeo string, 
 		LEFT JOIN series
 		    ON series.id = measurement_series.series_id
 		   AND NOT series.restricted
-		LEFT JOIN geographies ON geographies.id = series.geography_id
+		LEFT JOIN category_geographies cg ON cg.category_id = categories.id
+		LEFT JOIN category_frequencies cf ON cf.category_id = categories.id
+		LEFT JOIN geographies ON
+			(CASE WHEN EXISTS(SELECT * FROM category_geographies WHERE category_id = categories.id)
+				  THEN geographies.id = cg.geography_id ELSE true
+			 END)
 		LEFT JOIN public_data_points ON public_data_points.series_id = series.id
 		WHERE categories.id = ?
+		AND series.geography_id = geographies.id
+		AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id = categories.id)
+				  THEN series.frequency = cf.frequency ELSE true
+			 END)
 		AND public_data_points.value IS NOT null /* suppress those with no public data */
 		GROUP BY categories.id, geographies.id, RIGHT(series.name, 1)  ;`, id)
 	if err != nil {

--- a/data/common.go
+++ b/data/common.go
@@ -172,9 +172,10 @@ func getAllFreqsGeosByUniverse(r *SeriesRepository, seriesId int64, universe str
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
-		LEFT JOIN category_geographies cg ON cg.category_id in (select id from categories where universe = ?)
+		LEFT JOIN categories ON categories.universe = ?
+		LEFT JOIN category_geographies cg ON cg.category_id = categories.id
 		LEFT JOIN geographies geo ON
-			(CASE WHEN EXISTS(SELECT * FROM category_geographies WHERE category_id in (select id from categories where universe = ?))
+			(CASE WHEN EXISTS(SELECT * FROM category_geographies WHERE category_id = categories.id)
 				  THEN geo.id = cg.geography_id ELSE true
 			 END)
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
@@ -188,15 +189,16 @@ func getAllFreqsGeosByUniverse(r *SeriesRepository, seriesId int64, universe str
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
-		LEFT JOIN category_frequencies cf ON  cf.category_id in (select id from categories where universe = ?)
+		LEFT JOIN categories ON categories.universe = ?
+		LEFT JOIN category_frequencies cf ON cf.category_id = categories.id
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
 		WHERE pdp.value IS NOT NULL
 		AND measurement_series.series_id = ?
-		AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id in (select id from categories where universe = ?))
+		AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id = categories.id)
 				  THEN series.frequency = cf.frequency ELSE true
 			 END)
 		GROUP BY RIGHT(series.name, 1)
-		ORDER BY 1,2 ;`, universe, universe, seriesId, universe, seriesId, universe)
+		ORDER BY 1,2 ;`, universe, seriesId, universe, seriesId)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/data/common.go
+++ b/data/common.go
@@ -164,16 +164,10 @@ func getAllFreqsGeos(r *SeriesRepository, seriesId int64) (
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
-		LEFT JOIN categories ON categories.universe = ?
-		LEFT JOIN category_geographies cg ON cg.category_id = categories.id
-		LEFT JOIN geographies geo ON
-			(CASE WHEN EXISTS(SELECT * FROM category_geographies WHERE category_id = categories.id)
-				  THEN geo.id = cg.geography_id ELSE true
-			 END)
+		LEFT JOIN geographies geo on geo.id = series.geography_id
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
 		WHERE pdp.value IS NOT NULL
 		AND measurement_series.series_id = ?
-		AND series.geography_id = geo.geography_id
 		GROUP BY geo.id
 		   UNION
 		SELECT DISTINCT 'freq' AS gftype,
@@ -181,14 +175,9 @@ func getAllFreqsGeos(r *SeriesRepository, seriesId int64) (
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
-		LEFT JOIN categories ON categories.universe = ?
-		LEFT JOIN category_frequencies cf ON cf.category_id = categories.id
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
 		WHERE pdp.value IS NOT NULL
 		AND measurement_series.series_id = ?
-		AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id = categories.id)
-				  THEN series.frequency = cf.frequency ELSE true
-			 END)
 		GROUP BY RIGHT(series.name, 1)
 		ORDER BY 1,2 ;`, seriesId, seriesId)
 	if err != nil {

--- a/data/common.go
+++ b/data/common.go
@@ -154,6 +154,14 @@ func getAllFreqsGeos(r *SeriesRepository, seriesId int64) (
 	[]models.DataPortalFrequency,
 	error,
 ) {
+	return getAllFreqsGeosByUniverse(r, seriesId, "UHERO")
+}
+
+func getAllFreqsGeosByUniverse(r *SeriesRepository, seriesId int64, universe string) (
+	[]models.DataPortalGeography,
+	[]models.DataPortalFrequency,
+	error,
+) {
 	rows, err := r.DB.Query(
 		`SELECT DISTINCT 'geo' AS gftype,
 			ANY_VALUE(geo.handle) AS handle,
@@ -173,7 +181,7 @@ func getAllFreqsGeos(r *SeriesRepository, seriesId int64) (
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
 		WHERE pdp.value IS NOT NULL
 		AND measurement_series.series_id = ?
-		AND series.geography_id = geo.geography_id
+		AND series.geography_id = geo.id
 		GROUP BY geo.id
 		   UNION
 		SELECT DISTINCT 'freq' AS gftype,
@@ -190,7 +198,7 @@ func getAllFreqsGeos(r *SeriesRepository, seriesId int64) (
 				  THEN series.frequency = cf.frequency ELSE true
 			 END)
 		GROUP BY RIGHT(series.name, 1)
-		ORDER BY 1,2 ;`, seriesId, seriesId)
+		ORDER BY 1,2 ;`, universe, seriesId, universe, seriesId)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/data/common.go
+++ b/data/common.go
@@ -164,10 +164,16 @@ func getAllFreqsGeos(r *SeriesRepository, seriesId int64) (
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
-		LEFT JOIN geographies geo on geo.id = series.geography_id
+		LEFT JOIN categories ON categories.universe = ?
+		LEFT JOIN category_geographies cg ON cg.category_id = categories.id
+		LEFT JOIN geographies geo ON
+			(CASE WHEN EXISTS(SELECT * FROM category_geographies WHERE category_id = categories.id)
+				  THEN geo.id = cg.geography_id ELSE true
+			 END)
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
 		WHERE pdp.value IS NOT NULL
 		AND measurement_series.series_id = ?
+		AND series.geography_id = geo.geography_id
 		GROUP BY geo.id
 		   UNION
 		SELECT DISTINCT 'freq' AS gftype,
@@ -175,9 +181,14 @@ func getAllFreqsGeos(r *SeriesRepository, seriesId int64) (
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
+		LEFT JOIN categories ON categories.universe = ?
+		LEFT JOIN category_frequencies cf ON cf.category_id = categories.id
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
 		WHERE pdp.value IS NOT NULL
 		AND measurement_series.series_id = ?
+		AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id = categories.id)
+				  THEN series.frequency = cf.frequency ELSE true
+			 END)
 		GROUP BY RIGHT(series.name, 1)
 		ORDER BY 1,2 ;`, seriesId, seriesId)
 	if err != nil {

--- a/data/common.go
+++ b/data/common.go
@@ -154,14 +154,6 @@ func getAllFreqsGeos(r *SeriesRepository, seriesId int64) (
 	[]models.DataPortalFrequency,
 	error,
 ) {
-	return getAllFreqsGeosByUniverse(r, seriesId, "UHERO")
-}
-
-func getAllFreqsGeosByUniverse(r *SeriesRepository, seriesId int64, universe string) (
-	[]models.DataPortalGeography,
-	[]models.DataPortalFrequency,
-	error,
-) {
 	rows, err := r.DB.Query(
 		`SELECT DISTINCT 'geo' AS gftype,
 			ANY_VALUE(geo.handle) AS handle,
@@ -181,7 +173,7 @@ func getAllFreqsGeosByUniverse(r *SeriesRepository, seriesId int64, universe str
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
 		WHERE pdp.value IS NOT NULL
 		AND measurement_series.series_id = ?
-		AND series.geography_id = geo.id
+		AND series.geography_id = geo.geography_id
 		GROUP BY geo.id
 		   UNION
 		SELECT DISTINCT 'freq' AS gftype,
@@ -198,7 +190,7 @@ func getAllFreqsGeosByUniverse(r *SeriesRepository, seriesId int64, universe str
 				  THEN series.frequency = cf.frequency ELSE true
 			 END)
 		GROUP BY RIGHT(series.name, 1)
-		ORDER BY 1,2 ;`, universe, seriesId, universe, seriesId)
+		ORDER BY 1,2 ;`, seriesId, seriesId)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/data/common.go
+++ b/data/common.go
@@ -172,10 +172,9 @@ func getAllFreqsGeosByUniverse(r *SeriesRepository, seriesId int64, universe str
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
-		LEFT JOIN categories ON categories.universe = ?
-		LEFT JOIN category_geographies cg ON cg.category_id = categories.id
+		LEFT JOIN category_geographies cg ON cg.category_id in (select id from categories where universe = ?)
 		LEFT JOIN geographies geo ON
-			(CASE WHEN EXISTS(SELECT * FROM category_geographies WHERE category_id = categories.id)
+			(CASE WHEN EXISTS(SELECT * FROM category_geographies WHERE category_id in (select id from categories where universe = ?))
 				  THEN geo.id = cg.geography_id ELSE true
 			 END)
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
@@ -189,16 +188,15 @@ func getAllFreqsGeosByUniverse(r *SeriesRepository, seriesId int64, universe str
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
-		LEFT JOIN categories ON categories.universe = ?
-		LEFT JOIN category_frequencies cf ON cf.category_id = categories.id
+		LEFT JOIN category_frequencies cf ON  cf.category_id in (select id from categories where universe = ?)
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
 		WHERE pdp.value IS NOT NULL
 		AND measurement_series.series_id = ?
-		AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id = categories.id)
+		AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id in (select id from categories where universe = ?))
 				  THEN series.frequency = cf.frequency ELSE true
 			 END)
 		GROUP BY RIGHT(series.name, 1)
-		ORDER BY 1,2 ;`, universe, seriesId, universe, seriesId)
+		ORDER BY 1,2 ;`, universe, universe, seriesId, universe, seriesId, universe)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/data/geoRepository.go
+++ b/data/geoRepository.go
@@ -48,11 +48,20 @@ func (r *GeographyRepository) GetGeographiesByCategory(categoryId int64) (geogra
 		LEFT JOIN data_list_measurements ON data_list_measurements.data_list_id = categories.data_list_id
 		LEFT JOIN measurement_series ON measurement_series.measurement_id = data_list_measurements.measurement_id
 		LEFT JOIN series ON series.id = measurement_series.series_id
-		LEFT JOIN geographies ON geographies.id = series.geography_id
+		LEFT JOIN category_geographies cg ON cg.category_id = categories.id
+		LEFT JOIN category_frequencies cf ON cf.category_id = categories.id
+		LEFT JOIN geographies ON
+			(CASE WHEN EXISTS(SELECT * FROM category_geographies WHERE category_id = categories.id)
+				  THEN geographies.id = cg.geography_id ELSE true
+			 END)
 		LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 		WHERE (categories.id = ? OR categories.ancestry REGEXP CONCAT('[[:<:]]', ?, '[[:>:]]'))
 		AND NOT (categories.hidden OR categories.masked)
 		AND NOT series.restricted
+		AND series.geography_id = geographies.id
+		AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id = categories.id)
+				  THEN series.frequency = cf.frequency ELSE true
+			 END)
 		AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined);`,
 		categoryId,
 		categoryId,

--- a/data/search.go
+++ b/data/search.go
@@ -85,19 +85,19 @@ func (r *SearchRepository) GetSearchSummaryByUniverse(searchText string, univers
 	    FROM public_data_points
 	    JOIN series ON series.id = public_data_points.series_id
 	    JOIN (
-	      SELECT series_id FROM measurement_series WHERE measurement_id IN (
-		SELECT measurement_id FROM data_list_measurements WHERE data_list_id IN (
-		  SELECT data_list_id FROM categories
-		  WHERE universe LIKE CONCAT('%',?,'%')
-		  AND ((MATCH(name) AGAINST(? IN NATURAL LANGUAGE MODE))
-		    OR (LOWER(COALESCE(name, '')) LIKE CONCAT('%', LOWER(?), '%')))
-		)
-	      )
-	      UNION
-	      SELECT id AS series_id FROM series
-	      WHERE universe LIKE CONCAT('%',?,'%')
-	      AND ((MATCH(name, description, dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
-	        OR LOWER(CONCAT(name, COALESCE(description, ''), COALESCE(dataPortalName, ''))) LIKE CONCAT('%', LOWER(?), '%'))
+			SELECT series_id FROM measurement_series WHERE measurement_id IN (
+				SELECT measurement_id FROM data_list_measurements WHERE data_list_id IN (
+					SELECT data_list_id FROM categories
+					WHERE universe LIKE CONCAT('%',?,'%')
+					AND ((MATCH(name) AGAINST(? IN NATURAL LANGUAGE MODE))
+						OR (LOWER(COALESCE(name, '')) LIKE CONCAT('%', LOWER(?), '%')))
+				)
+			)
+			UNION
+			SELECT id AS series_id FROM series
+			WHERE universe LIKE CONCAT('%',?,'%')
+			AND ((MATCH(name, description, dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
+				OR LOWER(CONCAT(name, COALESCE(description, ''), COALESCE(dataPortalName, ''))) LIKE CONCAT('%', LOWER(?), '%'))
 	    ) AS s ON s.series_id = series.id
 	    LEFT JOIN feature_toggles ft ON ft.universe = series.universe AND ft.name = 'filter_by_quarantine'
 	    WHERE NOT series.restricted

--- a/data/search.go
+++ b/data/search.go
@@ -14,6 +14,7 @@ type SearchRepository struct {
 }
 
 func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, universeText string) (seriesList []models.DataPortalSeries, err error) {
+	//language=MySQL
 	rows, err := r.DB.Query(`SELECT
 	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
@@ -78,6 +79,7 @@ func (r *SearchRepository) GetSearchSummaryByUniverse(searchText string, univers
 	searchSummary.SearchText = searchText
 
 	var observationStart, observationEnd models.NullTime
+	//language=MySQL
 	err = r.Series.DB.QueryRow(`
 	    SELECT MIN(public_data_points.date) AS start_date, MAX(public_data_points.date) AS end_date
 	    FROM public_data_points
@@ -123,6 +125,7 @@ func (r *SearchRepository) GetSearchSummaryByUniverse(searchText string, univers
 		searchSummary.DefaultFreq = rootCat.Defaults.Frequency
 	}
 
+	//language=MySQL
 	rows, err := r.Series.DB.Query(`
 	SELECT DISTINCT geo.fips, geo.display_name, geo.display_name_short, geo.handle AS geo, RIGHT(series.name, 1) as freq
 	FROM series
@@ -214,6 +217,7 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreqAndUniverse(
 	freq string,
 	universeText string,
 ) (seriesList []models.DataPortalSeries, err error) {
+	//language=MySQL
 	rows, err := r.DB.Query(`SELECT
 	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
@@ -290,6 +294,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 	freq string,
 	universeText string,
 ) (seriesList []models.InflatedSeries, err error) {
+	//language=MySQL
 	rows, err := r.DB.Query(`SELECT DISTINCT
 	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),

--- a/data/search.go
+++ b/data/search.go
@@ -129,13 +129,22 @@ func (r *SearchRepository) GetSearchSummaryByUniverse(searchText string, univers
 	rows, err := r.Series.DB.Query(`
 	SELECT DISTINCT geo.fips, geo.display_name, geo.display_name_short, geo.handle AS geo, RIGHT(series.name, 1) as freq
 	FROM series
-	LEFT JOIN geographies geo on geo.id = series.geography_id
 	LEFT JOIN measurement_series ON measurement_series.series_id = series.id
 	LEFT JOIN data_list_measurements ON data_list_measurements.measurement_id = measurement_series.measurement_id
 	LEFT JOIN categories ON categories.data_list_id = data_list_measurements.data_list_id
+	LEFT JOIN category_geographies cg ON cg.category_id = categories.id
+	LEFT JOIN category_frequencies cf ON cf.category_id = categories.id
+	LEFT JOIN geographies geo ON
+		(CASE WHEN EXISTS(SELECT * FROM category_geographies WHERE category_id = categories.id)
+			  THEN geo.id = cg.geography_id ELSE true
+		 END)
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE series.universe LIKE CONCAT('%',?,'%')
 	AND NOT series.restricted
+	AND series.geography_id = geo.id
+	AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id = categories.id)
+			  THEN series.frequency = cf.frequency ELSE true
+		 END)
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT quarantined)
 	AND ((MATCH(series.name, series.description, dataPortalName) AGAINST(? IN NATURAL LANGUAGE MODE))
 	  OR (MATCH(categories.name) AGAINST(? IN NATURAL LANGUAGE MODE))

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -637,6 +637,10 @@ func (r *SeriesRepository) GetSeriesSiblingsFreqById(
 }
 
 func (r *SeriesRepository) GetSeriesById(seriesId int64) (dataPortalSeries models.DataPortalSeries, err error) {
+	return r.GetSeriesByIdAndUniverse(seriesId, "UHERO")
+}
+
+func (r *SeriesRepository) GetSeriesByIdAndUniverse(seriesId int64, universe string) (dataPortalSeries models.DataPortalSeries, err error) {
 	row, err := r.DB.Query(`SELECT DISTINCT
 	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(measurement_units.long_label, '')),
@@ -670,7 +674,7 @@ func (r *SeriesRepository) GetSeriesById(seriesId int64) (dataPortalSeries model
 		if err != nil {
 			return
 		}
-		geos, freqs, err := getAllFreqsGeos(r, seriesId)
+		geos, freqs, err := getAllFreqsGeosByUniverse(r, seriesId, universe)
 		if err != nil {
 			return dataPortalSeries, err
 		}
@@ -810,7 +814,7 @@ func (r *SeriesRepository) CreateSeriesPackage(
 	categoryRepository *CategoryRepository,
 )  (pkg models.DataPortalSeriesPackage, err error) {
 
-	series, err := r.GetSeriesById(id)
+	series, err := r.GetSeriesByIdAndUniverse(id, universe)
 	if err != nil {
 		return
 	}

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -636,10 +636,6 @@ func (r *SeriesRepository) GetSeriesSiblingsFreqById(
 }
 
 func (r *SeriesRepository) GetSeriesById(seriesId int64) (dataPortalSeries models.DataPortalSeries, err error) {
-	return r.GetSeriesByIdAndUniverse(seriesId, "UHERO")
-}
-
-func (r *SeriesRepository) GetSeriesByIdAndUniverse(seriesId int64, universe string) (dataPortalSeries models.DataPortalSeries, err error) {
 	row, err := r.DB.Query(`SELECT DISTINCT
 	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(measurement_units.long_label, '')),
@@ -673,7 +669,7 @@ func (r *SeriesRepository) GetSeriesByIdAndUniverse(seriesId int64, universe str
 		if err != nil {
 			return
 		}
-		geos, freqs, err := getAllFreqsGeosByUniverse(r, seriesId, universe)
+		geos, freqs, err := getAllFreqsGeos(r, seriesId)
 		if err != nil {
 			return dataPortalSeries, err
 		}
@@ -813,7 +809,7 @@ func (r *SeriesRepository) CreateSeriesPackage(
 	categoryRepository *CategoryRepository,
 )  (pkg models.DataPortalSeriesPackage, err error) {
 
-	series, err := r.GetSeriesByIdAndUniverse(id, universe)
+	series, err := r.GetSeriesById(id)
 	if err != nil {
 		return
 	}

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -36,8 +36,8 @@ const (
 )
 
 var transformations map[string]transformation = map[string]transformation{
-	//language=SQL
 	Levels: { // untransformed value
+		//language=SQL
 		Statement: `SELECT date, value/units, (pseudo_history = b'1'), series.decimals
 		FROM public_data_points
 		LEFT JOIN series ON public_data_points.series_id = series.id
@@ -45,8 +45,8 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 1,
 		Label:            "lvl",
 	},
-	//language=SQL
 	YOYPercentChange: { // percent change from 1 year ago
+		//language=SQL
 		Statement: `SELECT t1.date, (t1.value/t2.last_value - 1)*100 AS yoy,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
 				FROM (SELECT series_id, value, date, pseudo_history, DATE_SUB(date, INTERVAL 1 YEAR) AS last_year
@@ -57,8 +57,8 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 2,
 		Label:            "pc1",
 	},
-	//language=SQL
 	YOYChange: { // change from 1 year ago
+		//language=SQL
 		Statement: `SELECT t1.date, (t1.value - t2.last_value)/series.units AS yoy,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
 				FROM (SELECT series_id, value, date, pseudo_history, DATE_SUB(date, INTERVAL 1 YEAR) AS last_year
@@ -69,8 +69,8 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 2,
 		Label:            "pc1",
 	},
-	//language=SQL
 	YTDChange: { // ytd change from 1 year ago
+		//language=SQL
 		Statement: `SELECT t1.date, (t1.ytd/t1.count - t2.last_ytd/t2.last_count)/series.units AS ytd,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
 	  FROM (SELECT date, value, series_id, pseudo_history, @sum := IF(@year = YEAR(date), @sum, 0) + value AS ytd,
@@ -87,8 +87,8 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 2,
 		Label:            "ytd",
 	},
-	//language=SQL
 	YTDPercentChange: { // ytd percent change from 1 year ago
+		//language=SQL
 		Statement: `SELECT t1.date, (t1.ytd/t2.last_ytd - 1)*100 AS ytd,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
       FROM (SELECT series_id, date, value, @sum := IF(@year = YEAR(date), @sum, 0) + value AS ytd,
@@ -103,8 +103,8 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 2,
 		Label:            "ytd",
 	},
-	//language=SQL
 	C5MAPercentChange: { // c5ma percent change from 1 year ago
+		//language=SQL
 		Statement: `SELECT t1.date, (t1.c5ma/t2.last_c5ma - 1)*100 AS c5ma, 
 			(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
 			FROM (SELECT pdp2.series_id, pdp1.date, CASE WHEN count(*) = 5 THEN avg(pdp2.value) ELSE NULL END AS c5ma, DATE_SUB(pdp1.date, INTERVAL 1 YEAR) AS last_year, pdp1.pseudo_history FROM
@@ -119,8 +119,8 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 4,
 		Label:            "c5ma",
 	},
-	//language=SQL
 	C5MAChange: { // cm5a change from 1 year ago
+		//language=SQL
 		Statement: `SELECT t1.date, (t1.c5ma - t2.last_c5ma)/series.units AS c5ma, 
 			(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
 			FROM (SELECT pdp2.series_id, pdp1.date, CASE WHEN count(*) = 5 THEN avg(pdp2.value) ELSE NULL END AS c5ma, DATE_SUB(pdp1.date, INTERVAL 1 YEAR) AS last_year, pdp1.pseudo_history FROM
@@ -155,7 +155,9 @@ var seriesPrefix = `SELECT
 	LEFT JOIN measurements ON measurements.id = measurement_series.measurement_id
 	LEFT JOIN data_list_measurements ON data_list_measurements.measurement_id = measurements.id
 	LEFT JOIN categories ON categories.data_list_id = data_list_measurements.data_list_id
-	LEFT JOIN geographies ON geographies.id = series.geography_id
+	LEFT JOIN category_geographies cg on cg.category_id = categories.id
+	LEFT JOIN geographies ON geographies.id = cg.geography_id
+						 AND geographies.id = series.geography_id /* ????????? */
 	LEFT JOIN units ON units.id = series.unit_id
 	LEFT JOIN units AS measurement_units ON measurement_units.id = measurements.unit_id
 	LEFT JOIN sources ON sources.id = series.source_id

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -200,8 +200,7 @@ var measurementSeriesPrefix = `SELECT
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
-	WHERE measurements.id = ?
-	AND NOT series.restricted
+	WHERE measurements.id = ? AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
 var geoFilter = ` AND geographies.handle = UPPER(?) `
 var freqFilter = ` AND series.frequency = ? `

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -36,6 +36,7 @@ const (
 )
 
 var transformations map[string]transformation = map[string]transformation{
+	//language=SQL
 	Levels: { // untransformed value
 		Statement: `SELECT date, value/units, (pseudo_history = b'1'), series.decimals
 		FROM public_data_points
@@ -44,6 +45,7 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 1,
 		Label:            "lvl",
 	},
+	//language=SQL
 	YOYPercentChange: { // percent change from 1 year ago
 		Statement: `SELECT t1.date, (t1.value/t2.last_value - 1)*100 AS yoy,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
@@ -55,6 +57,7 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 2,
 		Label:            "pc1",
 	},
+	//language=SQL
 	YOYChange: { // change from 1 year ago
 		Statement: `SELECT t1.date, (t1.value - t2.last_value)/series.units AS yoy,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
@@ -66,6 +69,7 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 2,
 		Label:            "pc1",
 	},
+	//language=SQL
 	YTDChange: { // ytd change from 1 year ago
 		Statement: `SELECT t1.date, (t1.ytd/t1.count - t2.last_ytd/t2.last_count)/series.units AS ytd,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
@@ -83,6 +87,7 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 2,
 		Label:            "ytd",
 	},
+	//language=SQL
 	YTDPercentChange: { // ytd percent change from 1 year ago
 		Statement: `SELECT t1.date, (t1.ytd/t2.last_ytd - 1)*100 AS ytd,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
@@ -98,6 +103,7 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 2,
 		Label:            "ytd",
 	},
+	//language=SQL
 	C5MAPercentChange: { // c5ma percent change from 1 year ago
 		Statement: `SELECT t1.date, (t1.c5ma/t2.last_c5ma - 1)*100 AS c5ma, 
 			(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
@@ -113,6 +119,7 @@ var transformations map[string]transformation = map[string]transformation{
 		PlaceholderCount: 4,
 		Label:            "c5ma",
 	},
+	//language=SQL
 	C5MAChange: { // cm5a change from 1 year ago
 		Statement: `SELECT t1.date, (t1.c5ma - t2.last_c5ma)/series.units AS c5ma, 
 			(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
@@ -130,6 +137,7 @@ var transformations map[string]transformation = map[string]transformation{
 	},
 }
 
+//language=SQL
 var seriesPrefix = `SELECT
 	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
@@ -159,6 +167,7 @@ var seriesPrefix = `SELECT
 	AND NOT categories.hidden
 	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
+//language=SQL
 var measurementSeriesPrefix = `SELECT
 	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
@@ -189,6 +198,7 @@ var freqFilter = ` AND series.frequency = ? `
 var measurementPostfix = ` GROUP BY series.id;`
 var sortStmt = ` GROUP BY series.id ORDER BY MAX(data_list_measurements.list_order);`
 var siblingSortStmt = ` GROUP BY series.id;`
+//language=SQL
 var siblingsPrefix = `SELECT
     series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -197,7 +197,8 @@ var measurementSeriesPrefix = `SELECT
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
-	WHERE measurements.id = ? AND NOT series.restricted
+	WHERE measurements.id = ?
+	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
 var geoFilter = ` AND geographies.handle = UPPER(?) `
 var freqFilter = ` AND series.frequency = ? `

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -159,9 +159,8 @@ var seriesPrefix = `SELECT
 	LEFT JOIN category_frequencies cf ON cf.category_id = categories.id
 	LEFT JOIN geographies ON
 	    (CASE WHEN EXISTS(SELECT * FROM category_geographies WHERE category_id = categories.id)
-	          THEN geographies.id = cg.geography_id
-	          ELSE true
-	    END)
+	          THEN geographies.id = cg.geography_id ELSE true
+	     END)
 	LEFT JOIN units ON units.id = series.unit_id
 	LEFT JOIN units AS measurement_units ON measurement_units.id = measurements.unit_id
 	LEFT JOIN sources ON sources.id = series.source_id
@@ -174,8 +173,7 @@ var seriesPrefix = `SELECT
 	AND NOT series.restricted
 	AND series.geography_id = geographies.id
 	AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id = categories.id)
-	          THEN series.frequency = cf.frequency
-	          ELSE true
+	          THEN series.frequency = cf.frequency ELSE true
 	     END)
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
 //language=MySQL
@@ -466,10 +464,14 @@ func (r *SeriesRepository) GetFreqByCategory(categoryId int64) (frequencies []mo
 	LEFT JOIN data_list_measurements ON data_list_measurements.data_list_id = categories.data_list_id
 	LEFT JOIN measurement_series ON measurement_series.measurement_id = data_list_measurements.measurement_id
 	LEFT JOIN series ON series.id = measurement_series.series_id
+	LEFT JOIN category_frequencies cf ON cf.category_id = categories.id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
 	WHERE categories.id = ?
 	AND NOT (categories.hidden OR categories.masked)
 	AND NOT series.restricted
+	AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id = categories.id)
+	          THEN series.frequency = cf.frequency ELSE true
+	     END)
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)
 	ORDER BY FIELD(freq, "A", "S", "Q", "M", "W", "D");`, categoryId)
 	if err != nil {

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -37,7 +37,7 @@ const (
 
 var transformations map[string]transformation = map[string]transformation{
 	Levels: { // untransformed value
-		//language=SQL
+		//language=MySQL
 		Statement: `SELECT date, value/units, (pseudo_history = b'1'), series.decimals
 		FROM public_data_points
 		LEFT JOIN series ON public_data_points.series_id = series.id
@@ -46,7 +46,7 @@ var transformations map[string]transformation = map[string]transformation{
 		Label:            "lvl",
 	},
 	YOYPercentChange: { // percent change from 1 year ago
-		//language=SQL
+		//language=MySQL
 		Statement: `SELECT t1.date, (t1.value/t2.last_value - 1)*100 AS yoy,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
 				FROM (SELECT series_id, value, date, pseudo_history, DATE_SUB(date, INTERVAL 1 YEAR) AS last_year
@@ -58,7 +58,7 @@ var transformations map[string]transformation = map[string]transformation{
 		Label:            "pc1",
 	},
 	YOYChange: { // change from 1 year ago
-		//language=SQL
+		//language=MySQL
 		Statement: `SELECT t1.date, (t1.value - t2.last_value)/series.units AS yoy,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
 				FROM (SELECT series_id, value, date, pseudo_history, DATE_SUB(date, INTERVAL 1 YEAR) AS last_year
@@ -70,7 +70,7 @@ var transformations map[string]transformation = map[string]transformation{
 		Label:            "pc1",
 	},
 	YTDChange: { // ytd change from 1 year ago
-		//language=SQL
+		//language=MySQL
 		Statement: `SELECT t1.date, (t1.ytd/t1.count - t2.last_ytd/t2.last_count)/series.units AS ytd,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
 	  FROM (SELECT date, value, series_id, pseudo_history, @sum := IF(@year = YEAR(date), @sum, 0) + value AS ytd,
@@ -88,7 +88,7 @@ var transformations map[string]transformation = map[string]transformation{
 		Label:            "ytd",
 	},
 	YTDPercentChange: { // ytd percent change from 1 year ago
-		//language=SQL
+		//language=MySQL
 		Statement: `SELECT t1.date, (t1.ytd/t2.last_ytd - 1)*100 AS ytd,
 				(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
       FROM (SELECT series_id, date, value, @sum := IF(@year = YEAR(date), @sum, 0) + value AS ytd,
@@ -104,7 +104,7 @@ var transformations map[string]transformation = map[string]transformation{
 		Label:            "ytd",
 	},
 	C5MAPercentChange: { // c5ma percent change from 1 year ago
-		//language=SQL
+		//language=MySQL
 		Statement: `SELECT t1.date, (t1.c5ma/t2.last_c5ma - 1)*100 AS c5ma, 
 			(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
 			FROM (SELECT pdp2.series_id, pdp1.date, CASE WHEN count(*) = 5 THEN avg(pdp2.value) ELSE NULL END AS c5ma, DATE_SUB(pdp1.date, INTERVAL 1 YEAR) AS last_year, pdp1.pseudo_history FROM
@@ -120,7 +120,7 @@ var transformations map[string]transformation = map[string]transformation{
 		Label:            "c5ma",
 	},
 	C5MAChange: { // cm5a change from 1 year ago
-		//language=SQL
+		//language=MySQL
 		Statement: `SELECT t1.date, (t1.c5ma - t2.last_c5ma)/series.units AS c5ma, 
 			(t1.pseudo_history = b'1') AND (t2.pseudo_history = b'1') AS ph, series.decimals
 			FROM (SELECT pdp2.series_id, pdp1.date, CASE WHEN count(*) = 5 THEN avg(pdp2.value) ELSE NULL END AS c5ma, DATE_SUB(pdp1.date, INTERVAL 1 YEAR) AS last_year, pdp1.pseudo_history FROM
@@ -137,7 +137,7 @@ var transformations map[string]transformation = map[string]transformation{
 	},
 }
 
-//language=SQL
+//language=MySQL
 var seriesPrefix = `SELECT
 	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
@@ -169,7 +169,7 @@ var seriesPrefix = `SELECT
 	AND NOT (categories.hidden OR categories.masked)
 	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
-//language=SQL
+//language=MySQL
 var measurementSeriesPrefix = `SELECT
 	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
@@ -200,7 +200,7 @@ var freqFilter = ` AND series.frequency = ? `
 var measurementPostfix = ` GROUP BY series.id;`
 var sortStmt = ` GROUP BY series.id ORDER BY MAX(data_list_measurements.list_order);`
 var siblingSortStmt = ` GROUP BY series.id;`
-//language=SQL
+//language=MySQL
 var siblingsPrefix = `SELECT
     series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),


### PR DESCRIPTION
Functionally relevant changes here are most of the changes to SQL. My apologies that there some unrelated ones mixed in, namely 1) addition of comments to allow IDE to do syntax coloring for SQL code, and 2) fixing the indentation whitespace on one large block of SQL (which is otherwise unchanged). I intend to do a better job using the tool (git) to prevent this situation in the future, but this time the changes were not well isolated in commits.

The endpoints affected by this change are the following:
`/v1/category?id=`
`/v1/category?id=&geo=&freq=`
The above two are essentially the same, but the first one assumes the geo/freq that are defaults for the category (including inheritance from parent). Because of the unique logic with which we developed this particular endpoint, to provide for the needs of the data portals, `null` may be returned for either of the `geos` or `freqs` members in the result in case a parameter that is being filtered out by the bridge tables is provided. I suppose this should never happen, because data portals will only request things that are possible within the restrictions of the universe in question)

`/v1/category/series?id=[geo=,freq=,...]`
The above represents a variety of endpoints with different GET parameters (all sharing one block of SQL), and the same caveat holds about null/empty members being returned.

`/v1/package/category?u=`
`/v1/package/category?id=&geo=&freq=`
Same caveat as above about null/empty members for these endpoints.

`/v1/category/geo?id=`
`/v1/category/freq?id=`
These final two endpoints should yield results straightforwardly with no caveats :=P

Test by changing the contents of the bridge tables to observe changes in the results. A very slight degredation of performance might be noted. It is the result of the SQL changes specifically in the file `data/common.go`, in a routine which is called inside loops. But this was necessary in order to get the Series screen (not mediated by categories) to show the right geo/freqs.