### PR TITLE
Return Frequency object arrays sorted by frequency, not alpha (UA-850)

### DIFF
--- a/data/common.go
+++ b/data/common.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"sort"
 )
 
 var freqLabel map[string]string = map[string]string{
@@ -229,6 +230,8 @@ func getAllFreqsGeos(r *SeriesRepository, seriesId int64) (
 			freqsResult = append(freqsResult, f)
 		}
 	}
+	sort.Sort(models.ByGeography(geosResult))
+	sort.Sort(models.ByFrequency(freqsResult))
 	return geosResult, freqsResult, err
 }
 


### PR DESCRIPTION
Turned out to be simple, applying `sort.Sort` to arrays that are generated inside a single function that is used by many (but not all) endpoints. Similar arrays in other methods are already being sorted. Here is a sampling of endpoints to compare the difference:
`/v1/search/series?q=tax&u=uhero&geo=MAU&freq=A`
`/v1/series/siblings?id=152244`
`/v1/category/series?id=18&expand=true`
The one place on the data portal UI where this misordering was most apparent - the pulldown menu on the following page - is now fixed:
`/series?id=153609&sa=true`