### PR TITLE
reset proxy response headers

### DIFF
--- a/data/censusProxy.go
+++ b/data/censusProxy.go
@@ -25,8 +25,7 @@ func (t *CensusTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	body := ioutil.NopCloser(bytes.NewReader(b))
-	response.Body = body
+	response = SetCensusResponse(bytes.NewBuffer(b), "application/json")
 	WriteCachePair(r, t.CacheRepository, b)
 	return response, err
 }


### PR DESCRIPTION
(This is not urgent.)
There is an endpoint that fetches data from ACS and the response is writing multiple "Access-Control-Allow-Origin" headers. This seems to be creating a CORS error when using this endpoint in the new ACS dashboard.