### PR TITLE
COH Portal - Limit Series screen pull-down geos to HAW + HI (UA-985)

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -110,7 +110,7 @@ func returnInflatedSeriesList(seriesList []models.InflatedSeries, err error, w h
 	WriteCache(r, c, j)
 }
 
-func getIntParamByName(r *http.Request, name string) (id int64, ok bool) {
+func getIntParam(r *http.Request, name string) (id int64, ok bool) {
 	ok = true
 	param, ok := mux.Vars(r)[name]
 	if !ok {
@@ -125,7 +125,7 @@ func getIntParamByName(r *http.Request, name string) (id int64, ok bool) {
 }
 
 func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
-	id, ok = getIntParamByName(r, "id")
+	id, ok = getIntParam(r, "id")
 	if !ok {
 		common.DisplayAppError(w, errors.New("couldn't get integer id from request"),"Bad request.",400)
 	}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -111,31 +111,25 @@ func returnInflatedSeriesList(seriesList []models.InflatedSeries, err error, w h
 	WriteCache(r, c, j)
 }
 
-func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
+func getIdByName(w http.ResponseWriter, r *http.Request, name string) (id int64, ok bool) {
 	ok = true
-	idParam, gotId := mux.Vars(r)["id"]
+	idParam, gotId := mux.Vars(r)[name]
 	if !gotId {
-		common.DisplayAppError(
-			w,
-			errors.New("couldn't get id from request"),
-			"Bad request.",
-			400,
-		)
+		common.DisplayAppError(w, errors.New("couldn't get id from request"), "Bad request.", 400)
 		ok = false
 		return
 	}
 	id, err := strconv.ParseInt(idParam, 10, 64)
 	if err != nil {
-		common.DisplayAppError(
-			w,
-			err,
-			"An unexpected error has occurred",
-			500,
-		)
+		common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 		ok = false
 		return
 	}
 	return
+}
+
+func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
+	return getIdByName(w, r, "id")
 }
 
 func getIdsList(w http.ResponseWriter, r *http.Request) (ids []int64, ok bool) {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -117,7 +117,7 @@ func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
 	if !gotId {
 		common.DisplayAppError(
 			w,
-			errors.New("Couldn't get id from request"),
+			errors.New("couldn't get id from request"),
 			"Bad request.",
 			400,
 		)
@@ -142,7 +142,7 @@ func getIdsList(w http.ResponseWriter, r *http.Request) (ids []int64, ok bool) {
 	ok = true
 	idsList, gotIds := mux.Vars(r)["ids_list"]
 	if !gotIds {
-		common.DisplayAppError(w, errors.New("Couldn't get id from request"), "Bad request.", 400)
+		common.DisplayAppError(w, errors.New("couldn't get id from request"), "Bad request.", 400)
 		ok = false
 		return
 	}
@@ -165,7 +165,7 @@ func getIdAndGeo(w http.ResponseWriter, r *http.Request) (id int64, geo string, 
 	if !gotId {
 		common.DisplayAppError(
 			w,
-			errors.New("Couldn't get category id from request"),
+			errors.New("couldn't get category id from request"),
 			"Bad request.",
 			400,
 		)
@@ -187,7 +187,7 @@ func getIdAndGeo(w http.ResponseWriter, r *http.Request) (id int64, geo string, 
 	if !gotGeo {
 		common.DisplayAppError(
 			w,
-			errors.New("Couldn't get geography handle from request"),
+			errors.New("couldn't get geography handle from request"),
 			"Bad request.",
 			400,
 		)
@@ -203,7 +203,7 @@ func getIdAndFreq(w http.ResponseWriter, r *http.Request) (id int64, freq string
 	if !gotId {
 		common.DisplayAppError(
 			w,
-			errors.New("Couldn't get category id from request"),
+			errors.New("couldn't get category id from request"),
 			"Bad request.",
 			400,
 		)
@@ -225,7 +225,7 @@ func getIdAndFreq(w http.ResponseWriter, r *http.Request) (id int64, freq string
 	if !gotFreq {
 		common.DisplayAppError(
 			w,
-			errors.New("Couldn't get frequency from request"),
+			errors.New("couldn't get frequency from request"),
 			"Bad request.",
 			400,
 		)
@@ -239,13 +239,13 @@ func getGeoAndFreq(w http.ResponseWriter, r *http.Request) (geo string, freq str
 	ok = true
 	geo, gotGeo := mux.Vars(r)["geo"]
 	if !gotGeo {
-		common.DisplayAppError(w, errors.New("Couldn't get geography handle from request"), "Bad request.", 400)
+		common.DisplayAppError(w, errors.New("couldn't get geography handle from request"), "Bad request.", 400)
 		ok = false
 		return
 	}
 	freq, gotFreq := mux.Vars(r)["freq"]
 	if !gotFreq {
-		common.DisplayAppError(w, errors.New("Couldn't get frequency from request"), "Bad request.", 400)
+		common.DisplayAppError(w, errors.New("couldn't get frequency from request"), "Bad request.", 400)
 		ok = false
 		return
 	}
@@ -258,7 +258,7 @@ func getIdGeoAndFreq(w http.ResponseWriter, r *http.Request) (id int64, geo stri
 	if !gotId {
 		common.DisplayAppError(
 			w,
-			errors.New("Couldn't get category id from request"),
+			errors.New("couldn't get category id from request"),
 			"Bad request.",
 			400,
 		)
@@ -280,7 +280,7 @@ func getIdGeoAndFreq(w http.ResponseWriter, r *http.Request) (id int64, geo stri
 	if !gotGeo {
 		common.DisplayAppError(
 			w,
-			errors.New("Couldn't get geography handle from request"),
+			errors.New("couldn't get geography handle from request"),
 			"Bad request.",
 			400,
 		)
@@ -291,7 +291,7 @@ func getIdGeoAndFreq(w http.ResponseWriter, r *http.Request) (id int64, geo stri
 	if !gotFreq {
 		common.DisplayAppError(
 			w,
-			errors.New("Couldn't get frequency from request"),
+			errors.New("couldn't get frequency from request"),
 			"Bad request.",
 			400,
 		)

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -110,7 +110,7 @@ func returnInflatedSeriesList(seriesList []models.InflatedSeries, err error, w h
 	WriteCache(r, c, j)
 }
 
-func getIntParamByName(w http.ResponseWriter, r *http.Request, name string) (id int64, ok bool) {
+func getIntParamByName(r *http.Request, name string) (id int64, ok bool) {
 	ok = true
 	param, ok := mux.Vars(r)[name]
 	if !ok {
@@ -125,7 +125,7 @@ func getIntParamByName(w http.ResponseWriter, r *http.Request, name string) (id 
 }
 
 func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
-	id, ok = getIntParamByName(w, r, "id")
+	id, ok = getIntParamByName(r, "id")
 	if !ok {
 		common.DisplayAppError(w, errors.New("couldn't get integer id from request"),"Bad request.",400)
 	}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -114,7 +114,6 @@ func getIntParamByName(w http.ResponseWriter, r *http.Request, name string) (id 
 	ok = true
 	param, gotIt := mux.Vars(r)[name]
 	if !gotIt {
-		common.DisplayAppError(w, errors.New("couldn't get parameter " + name + " from request"), "Bad request.", 400)
 		ok = false
 		return
 	}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-
 	"github.com/UHERO/rest-api/common"
 	"github.com/UHERO/rest-api/data"
 	"github.com/UHERO/rest-api/models"
@@ -111,15 +110,15 @@ func returnInflatedSeriesList(seriesList []models.InflatedSeries, err error, w h
 	WriteCache(r, c, j)
 }
 
-func getIdByName(w http.ResponseWriter, r *http.Request, name string) (id int64, ok bool) {
+func getIntParamByName(w http.ResponseWriter, r *http.Request, name string) (id int64, ok bool) {
 	ok = true
-	idParam, gotId := mux.Vars(r)[name]
-	if !gotId {
-		common.DisplayAppError(w, errors.New("couldn't get id from request"), "Bad request.", 400)
+	param, gotIt := mux.Vars(r)[name]
+	if !gotIt {
+		common.DisplayAppError(w, errors.New("couldn't get parameter " + name + " from request"), "Bad request.", 400)
 		ok = false
 		return
 	}
-	id, err := strconv.ParseInt(idParam, 10, 64)
+	id, err := strconv.ParseInt(param, 10, 64)
 	if err != nil {
 		common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 		ok = false
@@ -129,14 +128,14 @@ func getIdByName(w http.ResponseWriter, r *http.Request, name string) (id int64,
 }
 
 func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
-	return getIdByName(w, r, "id")
+	return getIntParamByName(w, r, "id")
 }
 
 func getIdsList(w http.ResponseWriter, r *http.Request) (ids []int64, ok bool) {
 	ok = true
 	idsList, gotIds := mux.Vars(r)["ids_list"]
 	if !gotIds {
-		common.DisplayAppError(w, errors.New("couldn't get id from request"), "Bad request.", 400)
+		common.DisplayAppError(w, errors.New("couldn't get ids_list from request"), "Bad request.", 400)
 		ok = false
 		return
 	}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -112,14 +112,12 @@ func returnInflatedSeriesList(seriesList []models.InflatedSeries, err error, w h
 
 func getIntParamByName(w http.ResponseWriter, r *http.Request, name string) (id int64, ok bool) {
 	ok = true
-	param, gotIt := mux.Vars(r)[name]
-	if !gotIt {
-		ok = false
+	param, ok := mux.Vars(r)[name]
+	if !ok {
 		return
 	}
 	id, err := strconv.ParseInt(param, 10, 64)
 	if err != nil {
-		common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 		ok = false
 		return
 	}
@@ -127,7 +125,11 @@ func getIntParamByName(w http.ResponseWriter, r *http.Request, name string) (id 
 }
 
 func getId(w http.ResponseWriter, r *http.Request) (id int64, ok bool) {
-	return getIntParamByName(w, r, "id")
+	id, ok = getIntParamByName(w, r, "id")
+	if !ok {
+		common.DisplayAppError(w, errors.New("couldn't get integer id from request"),"Bad request.",400)
+	}
+	return
 }
 
 func getIdsList(w http.ResponseWriter, r *http.Request) (ids []int64, ok bool) {

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -137,7 +137,11 @@ func GetSeriesSiblingsById(seriesRepository *data.SeriesRepository, cacheReposit
 		if !ok {
 			return
 		}
-		seriesList, err := seriesRepository.GetSeriesSiblingsById(id)
+		catId, ok := getIntParamByName(w, r, "cat")
+		if !ok {
+			catId = 0
+		}
+		seriesList, err := seriesRepository.GetSeriesSiblingsById(id, catId)
 		returnSeriesList(seriesList, err, w, r, cacheRepository)
 	}
 }

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -136,7 +136,7 @@ func GetSeriesSiblingsById(seriesRepository *data.SeriesRepository, cacheReposit
 		if !ok {
 			return
 		}
-		catId, ok := getIntParamByName(r, "cat")
+		catId, ok := getIntParam(r, "cat")
 		if !ok {
 			catId = 0
 		}
@@ -282,7 +282,7 @@ func GetSeriesPackage(
 		if !ok {
 			return
 		}
-		catId, ok := getIntParamByName(r, "cat")
+		catId, ok := getIntParam(r, "cat")
 		if !ok {
 			catId = 0
 		}

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -280,7 +280,7 @@ func GetSeriesPackage(
 		}
 		catId, ok := getIdByName(w, r, "cat")
 		if !ok {
-			return
+			catId = 0
 		}
 		universe, ok := mux.Vars(r)["universe_text"]
 		if !ok {

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -7,6 +7,7 @@ import (
 	"github.com/UHERO/rest-api/common"
 	"github.com/UHERO/rest-api/data"
 	"github.com/gorilla/mux"
+	"fmt"
 )
 
 func GetSeriesByGroupId(
@@ -278,10 +279,11 @@ func GetSeriesPackage(
 		if !ok {
 			return
 		}
-		catId, ok := getIdByName(w, r, "cat")
+		catId, ok := getIntParamByName(w, r, "cat")
 		if !ok {
 			catId = 0
 		}
+		//fmt.Printf(">>>>>>>>>>>>>>>>>>>> category is %d\n",catId)
 		universe, ok := mux.Vars(r)["universe_text"]
 		if !ok {
 			return

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -7,7 +7,6 @@ import (
 	"github.com/UHERO/rest-api/common"
 	"github.com/UHERO/rest-api/data"
 	"github.com/gorilla/mux"
-	"fmt"
 )
 
 func GetSeriesByGroupId(
@@ -287,7 +286,6 @@ func GetSeriesPackage(
 		if !ok {
 			catId = 0
 		}
-		fmt.Printf(">>>>>>>>>>>>>>>>>>>> category is %d\n",catId)
 		universe, ok := mux.Vars(r)["universe_text"]
 		if !ok {
 			return

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -137,7 +137,7 @@ func GetSeriesSiblingsById(seriesRepository *data.SeriesRepository, cacheReposit
 		if !ok {
 			return
 		}
-		catId, ok := getIntParamByName(w, r, "cat")
+		catId, ok := getIntParamByName(r, "cat")
 		if !ok {
 			catId = 0
 		}
@@ -283,7 +283,7 @@ func GetSeriesPackage(
 		if !ok {
 			return
 		}
-		catId, ok := getIntParamByName(w, r, "cat")
+		catId, ok := getIntParamByName(r, "cat")
 		if !ok {
 			catId = 0
 		}

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -105,7 +105,7 @@ func GetSeriesById(seriesRepository *data.SeriesRepository, cacheRepository *dat
 		if !ok {
 			return
 		}
-		series, err := seriesRepository.GetSeriesById(id)
+		series, err := seriesRepository.GetSeriesById(id, 0)
 		if err != nil {
 			common.DisplayAppError(
 				w,
@@ -278,11 +278,15 @@ func GetSeriesPackage(
 		if !ok {
 			return
 		}
+		catId, ok := getIdByName(w, r, "cat")
+		if !ok {
+			return
+		}
 		universe, ok := mux.Vars(r)["universe_text"]
 		if !ok {
 			return
 		}
-		pkg, err := seriesRepository.CreateSeriesPackage(id, universe, categoryRepository)
+		pkg, err := seriesRepository.CreateSeriesPackage(id, universe, catId, categoryRepository)
 		if err != nil {
 			common.DisplayAppError(w, err, "An unexpected error has occurred", 500)
 			return

--- a/controllers/seriesController.go
+++ b/controllers/seriesController.go
@@ -283,7 +283,7 @@ func GetSeriesPackage(
 		if !ok {
 			catId = 0
 		}
-		//fmt.Printf(">>>>>>>>>>>>>>>>>>>> category is %d\n",catId)
+		fmt.Printf(">>>>>>>>>>>>>>>>>>>> category is %d\n",catId)
 		universe, ok := mux.Vars(r)["universe_text"]
 		if !ok {
 			return

--- a/data/common.go
+++ b/data/common.go
@@ -150,7 +150,7 @@ func getNextSeriesFromRows(rows *sql.Rows) (dataPortalSeries models.DataPortalSe
 	return
 }
 
-func getAllFreqsGeos(r *SeriesRepository, seriesId int64, catId int64) (
+func getAllFreqsGeos(r *SeriesRepository, seriesId int64, categoryId int64) (
 	[]models.DataPortalGeography,
 	[]models.DataPortalFrequency,
 	error,
@@ -189,7 +189,7 @@ func getAllFreqsGeos(r *SeriesRepository, seriesId int64, catId int64) (
 						  THEN series.frequency = cf.frequency ELSE true
 					 END)
 		GROUP BY RIGHT(series.name, 1)
-		ORDER BY 1,2 ;`, catId, catId, seriesId, catId, seriesId, catId)
+		ORDER BY 1,2 ;`, categoryId, categoryId, seriesId, categoryId, seriesId, categoryId)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/data/common.go
+++ b/data/common.go
@@ -150,7 +150,7 @@ func getNextSeriesFromRows(rows *sql.Rows) (dataPortalSeries models.DataPortalSe
 	return
 }
 
-func getAllFreqsGeos(r *SeriesRepository, seriesId int64) (
+func getAllFreqsGeos(r *SeriesRepository, seriesId int64, catId int64) (
 	[]models.DataPortalGeography,
 	[]models.DataPortalFrequency,
 	error,
@@ -165,22 +165,31 @@ func getAllFreqsGeos(r *SeriesRepository, seriesId int64) (
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
 		LEFT JOIN series ON series.id = ms.series_id
-		LEFT JOIN geographies geo on geo.id = series.geography_id
+		LEFT JOIN category_geographies cg ON cg.category_id = ?
+		LEFT JOIN geographies geo ON
+			(CASE WHEN EXISTS(SELECT * FROM category_geographies WHERE category_id = ?)
+				  THEN geo.id = cg.geography_id ELSE true
+			 END)
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
 		WHERE pdp.value IS NOT NULL
 		AND measurement_series.series_id = ?
+		AND series.geography_id = geo.id
 		GROUP BY geo.id
 		   UNION
 		SELECT DISTINCT 'freq' AS gftype,
 			RIGHT(series.name, 1) AS handle, null, null, null, MIN(pdp.date), MAX(pdp.date)
 		FROM measurement_series
 		LEFT JOIN measurement_series AS ms ON ms.measurement_id = measurement_series.measurement_id
+		LEFT JOIN category_frequencies cf ON cf.category_id = ?
 		LEFT JOIN series ON series.id = ms.series_id
 		LEFT JOIN public_data_points pdp on pdp.series_id = series.id
 		WHERE pdp.value IS NOT NULL
 		AND measurement_series.series_id = ?
+				AND (CASE WHEN EXISTS(SELECT * FROM category_frequencies WHERE category_id = ?)
+						  THEN series.frequency = cf.frequency ELSE true
+					 END)
 		GROUP BY RIGHT(series.name, 1)
-		ORDER BY 1,2 ;`, seriesId, seriesId)
+		ORDER BY 1,2 ;`, catId, catId, seriesId, catId, seriesId, catId)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/data/geoRepository.go
+++ b/data/geoRepository.go
@@ -41,38 +41,6 @@ func (r *GeographyRepository) GetAllGeographies() (geographies []models.DataPort
 	return
 }
 
-func (r *GeographyRepository) GetGeographiesByUniverse(universe string) (geographies []models.DataPortalGeography, err error) {
-	rows, err := r.DB.Query(`SELECT DISTINCT fips, display_name, display_name_short, handle
-									FROM categories WHERE universe = ?; `, universe)
-	if err != nil {
-		return
-	}
-	for rows.Next() {
-		geography := models.Geography{}
-		err = rows.Scan(
-			&geography.FIPS,
-			&geography.Name,
-			&geography.ShortName,
-			&geography.Handle,
-		)
-		if err != nil {
-			return
-		}
-		dataPortalGeography := models.DataPortalGeography{Handle: geography.Handle}
-		if geography.FIPS.Valid {
-			dataPortalGeography.FIPS = geography.FIPS.String
-		}
-		if geography.Name.Valid {
-			dataPortalGeography.Name = geography.Name.String
-		}
-		if geography.ShortName.Valid {
-			dataPortalGeography.ShortName = geography.ShortName.String
-		}
-		geographies = append(geographies, dataPortalGeography)
-	}
-	return
-}
-
 func (r *GeographyRepository) GetGeographiesByCategory(categoryId int64) (geographies []models.DataPortalGeography, err error) {
 	rows, err := r.DB.Query(
 		`SELECT DISTINCT geographies.fips, geographies.display_name, geographies.display_name_short, geographies.handle

--- a/data/search.go
+++ b/data/search.go
@@ -59,7 +59,7 @@ func (r *SeriesRepository) GetSeriesBySearchTextAndUniverse(searchText string, u
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, 0)
 		if err != nil {
 			return seriesList, err
 		}
@@ -272,7 +272,7 @@ func (r *SeriesRepository) GetSearchResultsByGeoAndFreqAndUniverse(
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, 0)
 		if err != nil {
 			return seriesList, err
 		}
@@ -348,7 +348,7 @@ func (r *SeriesRepository) GetInflatedSearchResultsByGeoAndFreqAndUniverse(
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, 0)
 		if err != nil {
 			return seriesList, err
 		}

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -244,6 +244,7 @@ func (r *SeriesRepository) GetSeriesByGroupAndFreq(
 ) (seriesList []models.DataPortalSeries, err error) {
 	prefix := seriesPrefix
 	sort := sortStmt
+	catId := groupId
 	if groupType == Measurement {
 		prefix = measurementSeriesPrefix
 		sort = measurementPostfix
@@ -280,9 +281,11 @@ func (r *SeriesRepository) GetSeriesByGroupGeoAndFreq(
 ) (seriesList []models.DataPortalSeries, err error) {
 	prefix := seriesPrefix
 	sort := sortStmt
+	catId := groupId
 	if groupType == Measurement {
 		prefix = measurementSeriesPrefix
 		sort = measurementPostfix
+		catId = 0
 	}
 	rows, err := r.DB.Query(
 		strings.Join([]string{prefix, geoFilter, freqFilter, sort}, ""),
@@ -298,7 +301,7 @@ func (r *SeriesRepository) GetSeriesByGroupGeoAndFreq(
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, catId)
 		if err != nil {
 			return seriesList, err
 		}
@@ -317,9 +320,11 @@ func (r *SeriesRepository) GetInflatedSeriesByGroupGeoAndFreq(
 ) (seriesList []models.InflatedSeries, err error) {
 	prefix := seriesPrefix
 	sort := sortStmt
+	catId := groupId
 	if groupType == Measurement {
 		prefix = measurementSeriesPrefix
 		sort = measurementPostfix
+		catId = 0
 	}
 	rows, err := r.DB.Query(
 		strings.Join([]string{prefix, geoFilter, freqFilter, sort}, ""),
@@ -335,7 +340,7 @@ func (r *SeriesRepository) GetInflatedSeriesByGroupGeoAndFreq(
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, catId)
 		if err != nil {
 			return seriesList, err
 		}
@@ -358,9 +363,11 @@ func (r *SeriesRepository) GetSeriesByGroupAndGeo(
 ) (seriesList []models.DataPortalSeries, err error) {
 	prefix := seriesPrefix
 	sort := sortStmt
+	catId := groupId
 	if groupType == Measurement {
 		prefix = measurementSeriesPrefix
 		sort = measurementPostfix
+		catId = 0
 	}
 	rows, err := r.DB.Query(
 		strings.Join([]string{prefix, geoFilter, sort}, ""),
@@ -375,7 +382,7 @@ func (r *SeriesRepository) GetSeriesByGroupAndGeo(
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, catId)
 		if err != nil {
 			return seriesList, err
 		}
@@ -392,9 +399,11 @@ func (r *SeriesRepository) GetInflatedSeriesByGroup(
 ) (seriesList []models.InflatedSeries, err error) {
 	prefix := seriesPrefix
 	sort := sortStmt
+	catId := groupId
 	if groupType == Measurement {
 		prefix = measurementSeriesPrefix
 		sort = measurementPostfix
+		catId = 0
 	}
 	rows, err := r.DB.Query(
 		strings.Join([]string{prefix, sort}, ""),
@@ -408,7 +417,7 @@ func (r *SeriesRepository) GetInflatedSeriesByGroup(
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, catId)
 		if err != nil {
 			return seriesList, err
 		}
@@ -430,9 +439,11 @@ func (r *SeriesRepository) GetSeriesByGroup(
 ) (seriesList []models.DataPortalSeries, err error) {
 	prefix := seriesPrefix
 	sort := sortStmt
+	catId := groupId
 	if groupType == Measurement {
 		prefix = measurementSeriesPrefix
 		sort = measurementPostfix
+		catId = 0
 	}
 	rows, err := r.DB.Query(
 		strings.Join([]string{prefix, sort}, ""),
@@ -446,7 +457,7 @@ func (r *SeriesRepository) GetSeriesByGroup(
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, catId)
 		if err != nil {
 			return seriesList, err
 		}
@@ -506,7 +517,7 @@ func (r *SeriesRepository) GetSeriesSiblingsById(seriesId int64) (seriesList []m
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, 0)
 		if err != nil {
 			return seriesList, err
 		}
@@ -534,7 +545,7 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdAndFreq(
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, 0)
 		if err != nil {
 			return seriesList, err
 		}
@@ -562,7 +573,7 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdAndGeo(
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, 0)
 		if err != nil {
 			return seriesList, err
 		}
@@ -592,7 +603,7 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdGeoAndFreq(
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, 0)
 		if err != nil {
 			return seriesList, err
 		}

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -647,7 +647,7 @@ func (r *SeriesRepository) GetSeriesSiblingsFreqById(
 	return
 }
 
-func (r *SeriesRepository) GetSeriesById(seriesId int64, catId int64) (dataPortalSeries models.DataPortalSeries, err error) {
+func (r *SeriesRepository) GetSeriesById(seriesId int64, categoryId int64) (dataPortalSeries models.DataPortalSeries, err error) {
 	row, err := r.DB.Query(`SELECT DISTINCT
 	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(measurement_units.long_label, '')),
@@ -682,7 +682,7 @@ func (r *SeriesRepository) GetSeriesById(seriesId int64, catId int64) (dataPorta
 		if err != nil {
 			return
 		}
-		geos, freqs, err := getAllFreqsGeos(r, seriesId, catId)
+		geos, freqs, err := getAllFreqsGeos(r, seriesId, categoryId)
 		if err != nil {
 			return dataPortalSeries, err
 		}
@@ -819,10 +819,11 @@ func (r *SeriesRepository) GetTransformation(
 func (r *SeriesRepository) CreateSeriesPackage(
 	id int64,
 	universe string,
+	categoryId int64,
 	categoryRepository *CategoryRepository,
 )  (pkg models.DataPortalSeriesPackage, err error) {
 
-	series, err := r.GetSeriesById(id)
+	series, err := r.GetSeriesById(id, categoryId)
 	if err != nil {
 		return
 	}
@@ -857,7 +858,7 @@ func (r *SeriesRepository) CreateAnalyzerPackage(
 	pkg.InflatedSeries = []models.InflatedSeries{}
 
 	for _, id := range ids {
-		series, anErr := r.GetSeriesById(id)
+		series, anErr := r.GetSeriesById(id, 0	)
 		if anErr != nil {
 			err = anErr
 			return

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -200,7 +200,8 @@ var measurementSeriesPrefix = `SELECT
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
-	WHERE measurements.id = ? AND NOT series.restricted
+	WHERE measurements.id = ?
+	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined)`
 var geoFilter = ` AND geographies.handle = UPPER(?) `
 var freqFilter = ` AND series.frequency = ? `
@@ -546,7 +547,7 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdAndFreq(
 ) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(strings.Join(
 		[]string{siblingsPrefix, freqFilter, siblingSortStmt}, ""),
-		seriesId,
+		seriesId, 0,
 		freqDbNames[strings.ToUpper(freq)],
 	)
 	if err != nil {
@@ -574,7 +575,7 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdAndGeo(
 ) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(
 		strings.Join([]string{siblingsPrefix, geoFilter, siblingSortStmt}, ""),
-		seriesId,
+		seriesId, 0,
 		geo,
 	)
 	if err != nil {
@@ -603,7 +604,7 @@ func (r *SeriesRepository) GetSeriesSiblingsByIdGeoAndFreq(
 ) (seriesList []models.DataPortalSeries, err error) {
 	rows, err := r.DB.Query(
 		strings.Join([]string{siblingsPrefix, geoFilter, freqFilter, siblingSortStmt}, ""),
-		seriesId,
+		seriesId, 0,
 		geo,
 		freqDbNames[strings.ToUpper(freq)],
 	)

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -248,6 +248,7 @@ func (r *SeriesRepository) GetSeriesByGroupAndFreq(
 	if groupType == Measurement {
 		prefix = measurementSeriesPrefix
 		sort = measurementPostfix
+		catId = 0
 	}
 	rows, err := r.DB.Query(
 		strings.Join([]string{prefix, freqFilter, sort}, ""),
@@ -262,7 +263,7 @@ func (r *SeriesRepository) GetSeriesByGroupAndFreq(
 		if scanErr != nil {
 			return seriesList, scanErr
 		}
-		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id)
+		geos, freqs, err := getAllFreqsGeos(r, dataPortalSeries.Id, catId)
 		if err != nil {
 			return seriesList, err
 		}

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -635,7 +635,7 @@ func (r *SeriesRepository) GetSeriesSiblingsFreqById(
 	return
 }
 
-func (r *SeriesRepository) GetSeriesById(seriesId int64) (dataPortalSeries models.DataPortalSeries, err error) {
+func (r *SeriesRepository) GetSeriesById(seriesId int64, catId int64) (dataPortalSeries models.DataPortalSeries, err error) {
 	row, err := r.DB.Query(`SELECT DISTINCT
 	series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(measurement_units.long_label, '')),
@@ -659,7 +659,8 @@ func (r *SeriesRepository) GetSeriesById(seriesId int64) (dataPortalSeries model
 	LEFT JOIN source_details ON source_details.id = series.source_detail_id
 	LEFT JOIN source_details AS measurement_source_details ON measurement_source_details.id = measurements.source_detail_id
 	LEFT JOIN feature_toggles ON feature_toggles.universe = series.universe AND feature_toggles.name = 'filter_by_quarantine'
-	WHERE series.id = ? AND NOT series.restricted
+	WHERE series.id = ?
+	AND NOT series.restricted
 	AND (feature_toggles.status IS NULL OR NOT feature_toggles.status OR NOT series.quarantined);`, seriesId)
 	if err != nil {
 		return
@@ -669,7 +670,7 @@ func (r *SeriesRepository) GetSeriesById(seriesId int64) (dataPortalSeries model
 		if err != nil {
 			return
 		}
-		geos, freqs, err := getAllFreqsGeos(r, seriesId)
+		geos, freqs, err := getAllFreqsGeos(r, seriesId, catId)
 		if err != nil {
 			return dataPortalSeries, err
 		}

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -209,7 +209,7 @@ var sortStmt = ` GROUP BY series.id ORDER BY MAX(data_list_measurements.list_ord
 var siblingSortStmt = ` GROUP BY series.id;`
 //language=MySQL
 var siblingsPrefix = `SELECT
-    series.id, series.name, series.universe, series.description, frequency, series.seasonally_adjusted, series.seasonal_adjustment,
+    series.id, series.name, series.universe, series.description, series.frequency, series.seasonally_adjusted, series.seasonal_adjustment,
 	COALESCE(NULLIF(units.long_label, ''), NULLIF(MAX(measurement_units.long_label), '')),
 	COALESCE(NULLIF(units.short_label, ''), NULLIF(MAX(measurement_units.short_label), '')),
 	COALESCE(NULLIF(series.dataPortalName, ''), MAX(measurements.data_portal_name)), series.percent, series.real,

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -870,7 +870,7 @@ func (r *SeriesRepository) CreateAnalyzerPackage(
 	pkg.InflatedSeries = []models.InflatedSeries{}
 
 	for _, id := range ids {
-		series, anErr := r.GetSeriesById(id, 0	)
+		series, anErr := r.GetSeriesById(id, 0)
 		if anErr != nil {
 			err = anErr
 			return

--- a/routers/package.go
+++ b/routers/package.go
@@ -18,7 +18,7 @@ func SetPackageRoutes(
 		controllers.GetSeriesPackage(seriesRepository, categoryRepository, cacheRepository),
 	).Methods("GET").Queries(
 		"id", "{id:[0-9]+}",
-		"cat", "{id:[0-9]+}",
+		"cat", "{cat:[0-9]+}",
 		"u", "{universe_text:.+}",
 	)
 	router.HandleFunc(

--- a/routers/package.go
+++ b/routers/package.go
@@ -22,6 +22,13 @@ func SetPackageRoutes(
 		"u", "{universe_text:.+}",
 	)
 	router.HandleFunc(
+		"/v1/package/series",
+		controllers.GetSeriesPackage(seriesRepository, categoryRepository, cacheRepository),
+	).Methods("GET").Queries(
+		"id", "{id:[0-9]+}",
+		"u", "{universe_text:.+}",
+	)
+	router.HandleFunc(
 		"/v1/package/search",
 		controllers.GetSearchPackage(searchRepository, cacheRepository),
 	).Methods("GET").Queries(

--- a/routers/package.go
+++ b/routers/package.go
@@ -18,6 +18,7 @@ func SetPackageRoutes(
 		controllers.GetSeriesPackage(seriesRepository, categoryRepository, cacheRepository),
 	).Methods("GET").Queries(
 		"id", "{id:[0-9]+}",
+		"cat", "{id:[0-9]+}",
 		"u", "{universe_text:.+}",
 	)
 	router.HandleFunc(

--- a/tests/Full_suite.postman_collection.json
+++ b/tests/Full_suite.postman_collection.json
@@ -1262,6 +1262,71 @@
 			"response": []
 		},
 		{
+			"name": "GET Series Package, Unknown category id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "53102755-96d2-44d6-b2ea-889ca8a85c0a",
+						"type": "text/javascript",
+						"exec": [
+							"var data = JSON.parse(responseBody).data;",
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"tests[\"Response contains data\"] = typeof(data) === 'object';",
+							"tests[\"Response contains a series object\"] = data.series !== undefined;",
+							"tests[\"Response categories is non-empty array\"] = Array.isArray(data.categories) && data.categories.length > 0;",
+							"tests[\"Response categories contains an element with name \"] = data.categories[0].name !== undefined;",
+							"tests[\"Response contains an observations object\"] = data.observations !== undefined;",
+							"tests[\"Response series has All 5 geos because cat unknown\"] = Array.isArray(data.series.geos) && data.series.geos.length == 5",
+							"tests[\"Response siblings is non-empty array\"] = Array.isArray(data.siblings) && data.siblings.length > 0;",
+							"tests[\"Response siblings have All 5 geos because cat unknown\"] = Array.isArray(data.siblings[0].geos) && data.siblings[0].geos.length == 5",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{uhero_auth_token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"body": {},
+				"url": {
+					"raw": "{{url}}/package/series?u=coh&id=148232&cat=99989",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"package",
+						"series"
+					],
+					"query": [
+						{
+							"key": "u",
+							"value": "coh"
+						},
+						{
+							"key": "id",
+							"value": "148232"
+						},
+						{
+							"key": "cat",
+							"value": "99989"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "GET Category series by id, expand",
 			"event": [
 				{

--- a/tests/Full_suite.postman_collection.json
+++ b/tests/Full_suite.postman_collection.json
@@ -1,8 +1,7 @@
 {
 	"info": {
+		"_postman_id": "bd2846ca-eedb-5b65-fee0-9eccb7e23cd1",
 		"name": "Full test suite",
-		"_postman_id": "ed987593-a16e-e51d-b1dd-d54eb1e265c1",
-		"description": "",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -102,8 +101,7 @@
 					"query": [
 						{
 							"key": "top_level",
-							"value": "true",
-							"equals": true
+							"value": "true"
 						}
 					]
 				},
@@ -159,8 +157,7 @@
 					"query": [
 						{
 							"key": "top_level",
-							"value": "false",
-							"equals": true
+							"value": "false"
 						}
 					]
 				},
@@ -212,17 +209,14 @@
 					"query": [
 						{
 							"key": "u",
-							"value": "uhero",
-							"equals": true
+							"value": "uhero"
 						},
 						{
 							"key": "type",
-							"value": "nav",
-							"equals": true
+							"value": "nav"
 						}
 					]
-				},
-				"description": ""
+				}
 			},
 			"response": []
 		},
@@ -274,8 +268,7 @@
 					"query": [
 						{
 							"key": "id",
-							"value": "16",
-							"equals": true
+							"value": "16"
 						}
 					]
 				},
@@ -331,8 +324,7 @@
 					"query": [
 						{
 							"key": "id",
-							"value": "999",
-							"equals": true
+							"value": "999"
 						}
 					]
 				},
@@ -386,8 +378,7 @@
 					"query": [
 						{
 							"key": "search_text",
-							"value": "summary",
-							"equals": true
+							"value": "summary"
 						}
 					]
 				},
@@ -439,8 +430,7 @@
 					"query": [
 						{
 							"key": "search_text",
-							"value": "nosuchtext",
-							"equals": true
+							"value": "nosuchtext"
 						}
 					]
 				},
@@ -495,8 +485,7 @@
 					"query": [
 						{
 							"key": "id",
-							"value": "16",
-							"equals": true
+							"value": "16"
 						}
 					]
 				},
@@ -551,8 +540,7 @@
 					"query": [
 						{
 							"key": "id",
-							"value": "22",
-							"equals": true
+							"value": "22"
 						}
 					]
 				},
@@ -607,8 +595,7 @@
 					"query": [
 						{
 							"key": "id",
-							"value": "34",
-							"equals": true
+							"value": "34"
 						}
 					]
 				},
@@ -663,8 +650,7 @@
 					"query": [
 						{
 							"key": "id",
-							"value": "34",
-							"equals": true
+							"value": "34"
 						}
 					]
 				},
@@ -719,13 +705,11 @@
 					"query": [
 						{
 							"key": "id",
-							"value": "34",
-							"equals": true
+							"value": "34"
 						},
 						{
 							"key": "geo",
-							"value": "HAW",
-							"equals": true
+							"value": "HAW"
 						}
 					]
 				},
@@ -780,13 +764,11 @@
 					"query": [
 						{
 							"key": "id",
-							"value": "34",
-							"equals": true
+							"value": "34"
 						},
 						{
 							"key": "freq",
-							"value": "Q",
-							"equals": true
+							"value": "Q"
 						}
 					]
 				},
@@ -841,18 +823,15 @@
 					"query": [
 						{
 							"key": "id",
-							"value": "34",
-							"equals": true
+							"value": "34"
 						},
 						{
 							"key": "geo",
-							"value": "HI",
-							"equals": true
+							"value": "HI"
 						},
 						{
 							"key": "freq",
-							"value": "Q",
-							"equals": true
+							"value": "Q"
 						}
 					]
 				},
@@ -906,17 +885,14 @@
 					"query": [
 						{
 							"key": "u",
-							"value": "uhero",
-							"equals": true
+							"value": "uhero"
 						},
 						{
 							"key": "ids",
-							"value": "152239,152240",
-							"equals": true
+							"value": "152239,152240"
 						}
 					]
-				},
-				"description": ""
+				}
 			},
 			"response": []
 		},
@@ -967,27 +943,22 @@
 					"query": [
 						{
 							"key": "u",
-							"value": "uhero",
-							"equals": true
+							"value": "uhero"
 						},
 						{
 							"key": "q",
-							"value": "exp",
-							"equals": true
+							"value": "exp"
 						},
 						{
 							"key": "geo",
-							"value": "HON",
-							"equals": true
+							"value": "HON"
 						},
 						{
 							"key": "freq",
-							"value": "Q",
-							"equals": true
+							"value": "Q"
 						}
 					]
-				},
-				"description": ""
+				}
 			},
 			"response": []
 		},
@@ -1038,17 +1009,14 @@
 					"query": [
 						{
 							"key": "u",
-							"value": "uhero",
-							"equals": true
+							"value": "uhero"
 						},
 						{
 							"key": "q",
-							"value": "exp",
-							"equals": true
+							"value": "exp"
 						}
 					]
-				},
-				"description": ""
+				}
 			},
 			"response": []
 		},
@@ -1100,22 +1068,18 @@
 					"query": [
 						{
 							"key": "id",
-							"value": "36",
-							"equals": true
+							"value": "36"
 						},
 						{
 							"key": "geo",
-							"value": "US",
-							"equals": true
+							"value": "US"
 						},
 						{
 							"key": "freq",
-							"value": "A",
-							"equals": true
+							"value": "A"
 						}
 					]
-				},
-				"description": ""
+				}
 			},
 			"response": []
 		},
@@ -1167,12 +1131,10 @@
 					"query": [
 						{
 							"key": "u",
-							"value": "uhero",
-							"equals": true
+							"value": "uhero"
 						}
 					]
-				},
-				"description": ""
+				}
 			},
 			"response": []
 		},
@@ -1223,17 +1185,79 @@
 					"query": [
 						{
 							"key": "u",
-							"value": "uhero",
-							"equals": true
+							"value": "uhero"
 						},
 						{
 							"key": "id",
-							"value": "148863",
-							"equals": true
+							"value": "148863"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GET Series Package, Limited Geos (COH)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "31cb96ac-6c3f-42cf-bdb5-65d170bf2e29",
+						"type": "text/javascript",
+						"exec": [
+							"var data = JSON.parse(responseBody).data;",
+							"tests[\"Status code is 200\"] = responseCode.code === 200;",
+							"tests[\"Response contains data\"] = typeof(data) === 'object';",
+							"tests[\"Response contains a series object\"] = data.series !== undefined;",
+							"tests[\"Response categories is non-empty array\"] = Array.isArray(data.categories) && data.categories.length > 0;",
+							"tests[\"Response categories contains an element with name \"] = data.categories[0].name !== undefined;",
+							"tests[\"Response contains an observations object\"] = data.observations !== undefined;",
+							"tests[\"Response series has two geos for COH\"] = Array.isArray(data.series.geos) && data.series.geos.length == 2",
+							"tests[\"Response siblings is non-empty array\"] = Array.isArray(data.siblings) && data.siblings.length > 0;",
+							"tests[\"Response siblings have two geos for COH\"] = Array.isArray(data.siblings[0].geos) && data.siblings[0].geos.length == 2",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{uhero_auth_token}}",
+							"type": "string"
 						}
 					]
 				},
-				"description": ""
+				"method": "GET",
+				"header": [],
+				"body": {},
+				"url": {
+					"raw": "{{url}}/package/series?u=coh&id=148232&cat=4430",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"package",
+						"series"
+					],
+					"query": [
+						{
+							"key": "u",
+							"value": "coh"
+						},
+						{
+							"key": "id",
+							"value": "148232"
+						},
+						{
+							"key": "cat",
+							"value": "4430"
+						}
+					]
+				}
 			},
 			"response": []
 		},
@@ -1284,13 +1308,11 @@
 					"query": [
 						{
 							"key": "id",
-							"value": "18",
-							"equals": true
+							"value": "18"
 						},
 						{
 							"key": "expand",
-							"value": "true",
-							"equals": true
+							"value": "true"
 						}
 					]
 				},


### PR DESCRIPTION
Add a `cat=` parameter to the `/package/series?id=&u=` endpoint, to send the category id that the series is current being viewed under on the data portal, so that georgraphies can be limited on COH portal to just the ones COH should see. This means that some methods need a new categoryId parameter.

Made some infrastructural changes to the way GET params are "gotten". Intend to spread this refactor throughout, later.

Full suite of Postman tests updated to include a test for this, so that can be one thing used for testing the PR.

Changed a bunch of error strings to start with lower case because GoLand told me to :=P
