### PR TITLE
GET param to bypass the cache (UA-881)

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -35,10 +35,15 @@ func CheckCache(c *data.CacheRepository) func(http.ResponseWriter, *http.Request
 func CheckCacheFresh(c *data.CacheRepository) func(http.ResponseWriter, *http.Request, http.HandlerFunc) {
 	return func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		url := data.GetCensusReqURI(r)
-		cached_val_fresh, _ := c.GetCache(url + ":fresh")
-		if cached_val_fresh != nil {
-			WriteResponse(w, cached_val_fresh)
-			return
+		nocache, _ := regexp.MatchString(`&nocache$`, url)
+		if nocache {
+			r.URL.RawQuery = strings.Replace(r.URL.RawQuery, "&nocache", "", -1)
+		} else {
+			cached_val_fresh, _ := c.GetCache(url + ":fresh")
+			if cached_val_fresh != nil {
+				WriteResponse(w, cached_val_fresh)
+				return
+			}
 		}
 		next(w, r)
 		return

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -22,9 +22,9 @@ func CheckCache(c *data.CacheRepository) func(http.ResponseWriter, *http.Request
 			r.URL.RawQuery = strings.Replace(r.URL.RawQuery, "&nocache", "", -1)
 			log.Printf("Bypassing cache lookup for URL %s", url)
 		} else {
-			cached_val, _ := c.GetCache(url)
-			if cached_val != nil {
-				WriteResponse(w, cached_val)
+			cachedVal, _ := c.GetCache(url)
+			if cachedVal != nil {
+				WriteResponse(w, cachedVal)
 				return
 			}
 		}
@@ -41,9 +41,9 @@ func CheckCacheFresh(c *data.CacheRepository) func(http.ResponseWriter, *http.Re
 			r.URL.RawQuery = strings.Replace(r.URL.RawQuery, "&nocache", "", -1)
 			log.Printf("Bypassing cache lookup for URL %s", url)
 		} else {
-			cached_val_fresh, _ := c.GetCache(url + ":fresh")
-			if cached_val_fresh != nil {
-				WriteResponse(w, cached_val_fresh)
+			freshCachedVal, _ := c.GetCache(url + ":fresh")
+			if freshCachedVal != nil {
+				WriteResponse(w, freshCachedVal)
 				return
 			}
 		}

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"github.com/UHERO/rest-api/common"
@@ -16,10 +17,15 @@ import (
 func CheckCache(c *data.CacheRepository) func(http.ResponseWriter, *http.Request, http.HandlerFunc) {
 	return func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		url := GetFullRelativeURL(r)
-		cached_val, _ := c.GetCache(url)
-		if cached_val != nil {
-			WriteResponse(w, cached_val)
-			return
+		nocache, _ := regexp.MatchString(`&nocache$`, url)
+		if nocache {
+			r.URL.RawQuery = strings.Replace(r.URL.RawQuery, "&nocache", "", -1)
+		} else {
+			cached_val, _ := c.GetCache(url)
+			if cached_val != nil {
+				WriteResponse(w, cached_val)
+				return
+			}
 		}
 		next(w, r)
 		return

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -20,6 +20,7 @@ func CheckCache(c *data.CacheRepository) func(http.ResponseWriter, *http.Request
 		nocache, _ := regexp.MatchString(`&nocache$`, url)
 		if nocache {
 			r.URL.RawQuery = strings.Replace(r.URL.RawQuery, "&nocache", "", -1)
+			log.Printf("Bypassing cache lookup for URL %s", url)
 		} else {
 			cached_val, _ := c.GetCache(url)
 			if cached_val != nil {
@@ -38,6 +39,7 @@ func CheckCacheFresh(c *data.CacheRepository) func(http.ResponseWriter, *http.Re
 		nocache, _ := regexp.MatchString(`&nocache$`, url)
 		if nocache {
 			r.URL.RawQuery = strings.Replace(r.URL.RawQuery, "&nocache", "", -1)
+			log.Printf("Bypassing cache lookup for URL %s", url)
 		} else {
 			cached_val_fresh, _ := c.GetCache(url + ":fresh")
 			if cached_val_fresh != nil {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -17,8 +17,7 @@ import (
 func CheckCache(c *data.CacheRepository) func(http.ResponseWriter, *http.Request, http.HandlerFunc) {
 	return func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		url := GetFullRelativeURL(r)
-		nocache, _ := regexp.MatchString(`&nocache$`, url)
-		if nocache {
+		if noCache, _ := regexp.MatchString(`&nocache$`, url); noCache {
 			r.URL.RawQuery = strings.Replace(r.URL.RawQuery, "&nocache", "", -1)
 			log.Printf("Bypassing cache lookup for URL %s", url)
 		} else {
@@ -36,8 +35,7 @@ func CheckCache(c *data.CacheRepository) func(http.ResponseWriter, *http.Request
 func CheckCacheFresh(c *data.CacheRepository) func(http.ResponseWriter, *http.Request, http.HandlerFunc) {
 	return func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		url := data.GetCensusReqURI(r)
-		nocache, _ := regexp.MatchString(`&nocache$`, url)
-		if nocache {
+		if noCache, _ := regexp.MatchString(`&nocache$`, url); noCache {
 			r.URL.RawQuery = strings.Replace(r.URL.RawQuery, "&nocache", "", -1)
 			log.Printf("Bypassing cache lookup for URL %s", url)
 		} else {

--- a/data/cacheRepository.go
+++ b/data/cacheRepository.go
@@ -20,7 +20,7 @@ func (r *CacheRepository) GetCache(key string) ([]byte, error) {
 		return nil, err
 	}
 	if value == nil {
-		log.Printf("Redis cached val nil on GET: %v", err)
+		//log.Printf("Redis cached val nil on GET: %v", err)
 		return nil, err
 	}
 	log.Printf("Redis GET: %s", key)
@@ -44,7 +44,7 @@ func (r *CacheRepository) SetCache(key string, value []byte) (err error) {
 		log.Print("Error on scan of redis response")
 	}
 	if setResponse != "OK" {
-		err = errors.New("Did not get OK from Redis SET")
+		err = errors.New("did not get OK from Redis SET")
 		log.Print(err)
 		return
 	}

--- a/data/cacheRepository.go
+++ b/data/cacheRepository.go
@@ -3,7 +3,6 @@ package data
 import (
 	"errors"
 	"log"
-
 	"github.com/garyburd/redigo/redis"
 )
 

--- a/data/search.go
+++ b/data/search.go
@@ -3,7 +3,6 @@ package data
 import (
 	"sort"
 	"time"
-
 	"github.com/UHERO/rest-api/models"
 	"strings"
 )


### PR DESCRIPTION
Allow `&nocache` to be put at end of API URLs (must be the last param) to bypass the cache lookup and go straight to the db. Results are still stored back to the cache.

Couple other manini cleanup-y things too.