### PR TITLE
Fix rounding of data values based on Decimals setting (U-1459)

### DIFF
--- a/data/common.go
+++ b/data/common.go
@@ -333,3 +333,17 @@ func rangeIntersection(start1 time.Time, end1 time.Time, start2 time.Time, end2 
 func rangesOverlap(start1 time.Time, end1 time.Time, start2 time.Time, end2 time.Time) bool {
 	return !(end1.Before(start2) || end2.Before(start1))
 }
+
+// strconv.FormatFloat cannot be used directly, because when rounding an exact half like 12.5, or rounding
+// something like 12.485 to two places (which reduces to an exact half), it displays "bizarre" behavior which
+// may or may not be the round-half-to-even method. Not worth the effort to figure out exactly what the heck
+// it is doing. But by adding a very tiny amount to each value, we can ensure that it implements the standard,
+// well-known rounding method in which halves are rounded up (or in the case of negatives, down)
+func floatRoundStringify(value float64, precision int) string {
+	if value < 0.0 {
+		value -= 0.00000001
+	} else {
+		value += 0.00000001
+	}
+	return strconv.FormatFloat(value, 'f', precision, 64)
+}

--- a/data/common.go
+++ b/data/common.go
@@ -334,6 +334,7 @@ func rangesOverlap(start1 time.Time, end1 time.Time, start2 time.Time, end2 time
 	return !(end1.Before(start2) || end2.Before(start1))
 }
 
+// Take a float value, round it according to precision, and return as a string.
 // strconv.FormatFloat cannot be used directly, because when rounding an exact half like 12.5, or rounding
 // something like 12.485 to two places (which reduces to an exact half), it displays "bizarre" behavior which
 // may or may not be the round-half-to-even method. Not worth the effort to figure out exactly what the heck

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -898,7 +898,7 @@ func (r *FooRepository) GetTransformation(
 			observationEnd = observation.Date
 		}
 		obsDates = append(obsDates, observation.Date.Format("2006-01-02"))
-		obsValues = append(obsValues, strconv.FormatFloat(observation.Value.Float64, 'f', observation.Decimals, 64))
+		obsValues = append(obsValues, floatRoundStringify(observation.Value.Float64, observation.Decimals))
 		obsPseudoHist = append(obsPseudoHist, observation.PseudoHistory.Bool)
 	}
 	rows.Close()
@@ -913,6 +913,15 @@ func (r *FooRepository) GetTransformation(
 	transformationResult.ObservationValues = obsValues
 	transformationResult.ObservationPHist = obsPseudoHist
 	return
+}
+
+func floatRoundStringify(value float64, precision int) string {
+	if value < 0.0 {
+		value -= 0.00000001
+	} else {
+		value += 0.00000001
+	}
+	return strconv.FormatFloat(value, 'f', precision, 64)
 }
 
 func (r *FooRepository) CreateSeriesPackage(

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -915,6 +915,11 @@ func (r *FooRepository) GetTransformation(
 	return
 }
 
+// strconv.FormatFloat cannot be used directly, because when rounding an exact half like 12.5, or rounding
+// something like 12.485 to two places (which reduces to an exact half), it displays "bizarre" behavior which
+// may or may not be the round-half-to-even method. Not worth the effort to figure out exactly what the heck
+// it is doing. But by adding a very tiny amount to each value, we can ensure that it implements the standard,
+// well know rounding method in which halves are rounded up (or in the case of negatives, down)
 func floatRoundStringify(value float64, precision int) string {
 	if value < 0.0 {
 		value -= 0.00000001

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -3,7 +3,6 @@ package data
 import (
 	"database/sql"
 	"github.com/UHERO/rest-api/models"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -913,20 +912,6 @@ func (r *FooRepository) GetTransformation(
 	transformationResult.ObservationValues = obsValues
 	transformationResult.ObservationPHist = obsPseudoHist
 	return
-}
-
-// strconv.FormatFloat cannot be used directly, because when rounding an exact half like 12.5, or rounding
-// something like 12.485 to two places (which reduces to an exact half), it displays "bizarre" behavior which
-// may or may not be the round-half-to-even method. Not worth the effort to figure out exactly what the heck
-// it is doing. But by adding a very tiny amount to each value, we can ensure that it implements the standard,
-// well-known rounding method in which halves are rounded up (or in the case of negatives, down)
-func floatRoundStringify(value float64, precision int) string {
-	if value < 0.0 {
-		value -= 0.00000001
-	} else {
-		value += 0.00000001
-	}
-	return strconv.FormatFloat(value, 'f', precision, 64)
 }
 
 func (r *FooRepository) CreateSeriesPackage(

--- a/data/seriesRepository.go
+++ b/data/seriesRepository.go
@@ -919,7 +919,7 @@ func (r *FooRepository) GetTransformation(
 // something like 12.485 to two places (which reduces to an exact half), it displays "bizarre" behavior which
 // may or may not be the round-half-to-even method. Not worth the effort to figure out exactly what the heck
 // it is doing. But by adding a very tiny amount to each value, we can ensure that it implements the standard,
-// well know rounding method in which halves are rounded up (or in the case of negatives, down)
+// well-known rounding method in which halves are rounded up (or in the case of negatives, down)
 func floatRoundStringify(value float64, precision int) string {
 	if value < 0.0 {
 		value -= 0.00000001


### PR DESCRIPTION
New rounding method... don't depend on Go library, but add 0.00000001 to each value before rounding, guarantees a "normal" rounding result.